### PR TITLE
Feature/fsa 987 previous alert link

### DIFF
--- a/drupal/sync/core.entity_form_display.node.alert.default.yml
+++ b/drupal/sync/core.entity_form_display.node.alert.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.alert.field_alert_modified
     - field.field.node.alert.field_alert_notation
     - field.field.node.alert.field_alert_otherbusiness
+    - field.field.node.alert.field_alert_previous
     - field.field.node.alert.field_alert_productdetails_raw
     - field.field.node.alert.field_alert_relatedmedia
     - field.field.node.alert.field_alert_reportingbusiness
@@ -86,6 +87,14 @@ content:
     region: content
   field_alert_otherbusiness:
     weight: 14
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_alert_previous:
+    weight: 25
     settings:
       size: 60
       placeholder: ''

--- a/drupal/sync/core.entity_view_display.node.alert.default.yml
+++ b/drupal/sync/core.entity_view_display.node.alert.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.alert.field_alert_modified
     - field.field.node.alert.field_alert_notation
     - field.field.node.alert.field_alert_otherbusiness
+    - field.field.node.alert.field_alert_previous
     - field.field.node.alert.field_alert_productdetails_raw
     - field.field.node.alert.field_alert_relatedmedia
     - field.field.node.alert.field_alert_reportingbusiness
@@ -21,6 +22,7 @@ dependencies:
     - node.type.alert
   module:
     - entity_print
+    - fsa_alerts
     - fsa_alerts_import
     - link
     - text
@@ -64,6 +66,13 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
+  field_alert_previous:
+    weight: 7
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: fsa_previous_alert
+    region: content
   field_alert_productdetails_raw:
     type: fsa_alert_json_formatter
     weight: 1

--- a/drupal/sync/field.field.node.alert.field_alert_previous.yml
+++ b/drupal/sync/field.field.node.alert.field_alert_previous.yml
@@ -1,0 +1,19 @@
+uuid: d5ef2b25-8ac4-4276-8843-55cafb0d1282
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_alert_previous
+    - node.type.alert
+id: node.alert.field_alert_previous
+field_name: field_alert_previous
+entity_type: node
+bundle: alert
+label: 'Previous alert'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/drupal/sync/field.storage.node.field_alert_previous.yml
+++ b/drupal/sync/field.storage.node.field_alert_previous.yml
@@ -1,0 +1,21 @@
+uuid: 2d9a8dd7-c4e3-4400-8561-569862cb14e3
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_alert_previous
+field_name: field_alert_previous
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/drupal/web/modules/custom/fsa_alerts/src/Plugin/Field/FieldFormatter/PreviousAlert.php
+++ b/drupal/web/modules/custom/fsa_alerts/src/Plugin/Field/FieldFormatter/PreviousAlert.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Drupal\fsa_alerts\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\Plugin\Field\FieldFormatter\BasicStringFormatter;
+use Drupal\Core\Link;
+use Drupal\node\NodeInterface;
+
+/**
+ * Plugin implementation of the 'fsa_previous_alert' formatter.
+ *
+ * Displays an alert notation value as a link to respective node.
+ *
+ * @FieldFormatter(
+ *   id = "fsa_previous_alert",
+ *   label = @Translation("Previous alert link"),
+ *   field_types = {
+ *     "string",
+ *   }
+ * )
+ */
+class PreviousAlert extends BasicStringFormatter {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $elements = [];
+
+    foreach ($items as $delta => $item) {
+      $link = FALSE;
+
+      // Get nodes that match with the notation ID. Although not by system but
+      // this field value is unique so should always return just one node
+      // object.
+      $nodes = \Drupal::entityTypeManager()
+        ->getStorage('node')
+        ->loadByProperties(['field_alert_notation' => $item->value]);
+
+      foreach ($nodes as $node) {
+        if ($node instanceof NodeInterface) {
+          $link = Link::createFromRoute($item->value . ': ' . $node->label(), 'entity.node.canonical', ['node' => $node->id()]);
+        }
+      }
+
+      if ($link) {
+        $elements[$delta] = [
+          '#type' => 'inline_template',
+          '#template' => '{{ value|nl2br }}',
+          '#context' => ['value' => $link],
+        ];
+      }
+    }
+
+    return $elements;
+  }
+
+}

--- a/drupal/web/modules/custom/fsa_alerts/src/Plugin/Field/FieldFormatter/PreviousAlert.php
+++ b/drupal/web/modules/custom/fsa_alerts/src/Plugin/Field/FieldFormatter/PreviousAlert.php
@@ -44,13 +44,15 @@ class PreviousAlert extends BasicStringFormatter {
         }
       }
 
-      if ($link) {
-        $elements[$delta] = [
-          '#type' => 'inline_template',
-          '#template' => '{{ value|nl2br }}',
-          '#context' => ['value' => $link],
-        ];
-      }
+      // In case there was no match to a node just display the field value.
+      $value = ($link) ? $link : $item->value;
+
+      $elements[$delta] = [
+        '#type' => 'inline_template',
+        '#template' => '{{ value|nl2br }}',
+        '#context' => ['value' => $value],
+      ];
+
     }
 
     return $elements;

--- a/drupal/web/modules/custom/fsa_alerts_import/src/Plugin/migrate/process/AlertItemProperties.php
+++ b/drupal/web/modules/custom/fsa_alerts_import/src/Plugin/migrate/process/AlertItemProperties.php
@@ -76,6 +76,12 @@ class AlertItemProperties extends ProcessPluginBase {
     }
     $row->setDestinationProperty('field_nation', $cids);
 
+    // Map previous alert, store only alert ID.
+    if (isset($item['previousAlert'])) {
+      $prev = AlertImportHelpers::getIdFromUri($item['previousAlert']['@id']);
+      $row->setDestinationProperty('field_alert_previous', $prev);
+    }
+
     // Map single textfield values.
     $mapping = [
       'SMStext' => 'field_alert_smstext',
@@ -85,6 +91,7 @@ class AlertItemProperties extends ProcessPluginBase {
     ];
     // Map single-values.
     foreach ($mapping as $key => $field) {
+
       if (is_string($item[$key])) {
         $row->setDestinationProperty($field, $item[$key]);
       }


### PR DESCRIPTION
This PR
* Stores previous alert id to new field 
* Adds a new field formatter to display the alert ID as a link in node view mode

Requires `drush mim --tag=alerts --update` to update existing data. `/news-alerts/alert/fsa-prin-10-2018-update-01` has this value in API.

Can be seen on dev: 
https://fsa.dev.wunder.io/news-alerts/alert/fsa-prin-10-2018-update-01