### PR TITLE
Bug/fsa 791 global search a11y

### DIFF
--- a/drupal/sync/block.block.search_link_tabs.yml
+++ b/drupal/sync/block.block.search_link_tabs.yml
@@ -19,9 +19,9 @@ provider: null
 plugin: fsa_link_tabs
 settings:
   id: fsa_link_tabs
-  label: 'Global search tabs'
+  label: 'Search categories'
   provider: fsa_custom
-  label_display: '0'
+  label_display: visible
   class: 'tab-row tab-row--capitalize'
   links:
     link-0:

--- a/drupal/sync/views.view.search_global_all.yml
+++ b/drupal/sync/views.view.search_global_all.yml
@@ -223,7 +223,17 @@ display:
           plugin_id: fsa_keyword
       sorts: {  }
       title: Search
-      header: {  }
+      header:
+        result:
+          id: result
+          table: views
+          field: result
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: false
+          content: "<h2 class=\"visually-hidden\">Search results</h2>\n<div class=\"visually-hidden\" aria-live=\"polite\">Showing @start-@end of @total</div>"
+          plugin_id: result
       footer:
         result:
           id: result

--- a/drupal/sync/views.view.search_global_guidance.yml
+++ b/drupal/sync/views.view.search_global_guidance.yml
@@ -353,7 +353,17 @@ display:
           plugin_id: fsa_guidance_content_type
       sorts: {  }
       title: Guidance
-      header: {  }
+      header:
+        result:
+          id: result
+          table: views
+          field: result
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          content: "<h2 class=\"visually-hidden\">Search results</h2>\n<div class=\"visually-hidden\" aria-live=\"polite\">Showing @start-@end of @total with current search filters.</div>"
+          plugin_id: result
       footer:
         result:
           id: result

--- a/drupal/sync/views.view.search_global_news_and_alerts.yml
+++ b/drupal/sync/views.view.search_global_news_and_alerts.yml
@@ -434,7 +434,17 @@ display:
           plugin_id: fsa_nation
       sorts: {  }
       title: 'News and alerts'
-      header: {  }
+      header:
+        result:
+          id: result
+          table: views
+          field: result
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          content: "<h2 class=\"visually-hidden\">Search results</h2>\n<div class=\"visually-hidden\" aria-live=\"polite\">Showing @start-@end of @total with current search filters.</div>"
+          plugin_id: result
       footer:
         result:
           id: result

--- a/drupal/sync/views.view.search_global_research.yml
+++ b/drupal/sync/views.view.search_global_research.yml
@@ -300,7 +300,17 @@ display:
           plugin_id: fsa_nation
       sorts: {  }
       title: Research
-      header: {  }
+      header:
+        result:
+          id: result
+          table: views
+          field: result
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          content: "<h2 class=\"visually-hidden\">Search results</h2>\n<div class=\"visually-hidden\" aria-live=\"polite\">Showing @start-@end of @total with current search filters.</div>"
+          plugin_id: result
       footer:
         result:
           id: result

--- a/drupal/web/themes/custom/fsa/inc/node.inc
+++ b/drupal/web/themes/custom/fsa/inc/node.inc
@@ -45,6 +45,7 @@ function fsa_preprocess_node(&$variables) {
       case 'alert':
         if ($node->hasField('field_alert_type')) {
           $tag = $node->field_alert_type->view([
+            'label' => 'hidden',
             'type' => 'fsa_alert_type_formatter',
           ]);
         }

--- a/drupal/web/themes/custom/fsa/template/base/page.html.twig
+++ b/drupal/web/themes/custom/fsa/template/base/page.html.twig
@@ -167,6 +167,7 @@
   </div>
   {% endif %}
 
+  <a id="main-content" tabindex="-1"></a>
   {% if (page.hero is defined and page.hero|render|striptags|trim) or (page.secondary_menu) %}
   <div class="layout hero-wrapper">
     <div class="layout__container">
@@ -214,7 +215,6 @@
     </div>
   {% endif %}
 
-    <a id="main-content" tabindex="-1"></a>
     <main role="main" class="layout layout--main {% if page.sidebar_first or page.sidebar_second %} layout--with-sidebar js-sticky-container{% else %} layout--with-no-sidebar{% endif %}{% if page.sidebar_second %} layout--with-secondary-sidebar{% endif %}">
       <div class="layout__container layout__container--main">
         {% if page.sidebar_first %}

--- a/drupal/web/themes/custom/fsa/template/block/block--fsa-link-tabs.html.twig
+++ b/drupal/web/themes/custom/fsa/template/block/block--fsa-link-tabs.html.twig
@@ -1,0 +1,38 @@
+{#
+/**
+ * @file
+ * Theme override to display a block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * @see template_preprocess_block()
+ */
+#}
+{% set heading_id = attributes.id ~ '-heading' |clean_id %}
+<div role="toolbar" aria-labelledby="{{ heading_id }}"{{ attributes|without('role', 'aria-labelledby') }}>
+  {{ title_prefix }}
+  {% if label %}
+    <h2{{ title_attributes.setAttribute('id', heading_id).addClass('visually-hidden') }}>{{ label }}</h2>
+  {% endif %}
+  {{ title_suffix }}
+  {% block content %}
+    {{ content }}
+  {% endblock %}
+</div>

--- a/drupal/web/themes/custom/fsa/template/content/node--search-result.html.twig
+++ b/drupal/web/themes/custom/fsa/template/content/node--search-result.html.twig
@@ -96,12 +96,12 @@
 
     {{ title_prefix }}
     {% if not page %}
-      <h2{{ title_attributes }}>
+      <h3{{ title_attributes }}>
         <a href="{{ url }}" rel="bookmark">{{ label }}</a>
-      </h2>
+      </h3>
     {% endif %}
     {{ title_suffix }}
-    
+
     <div{{ content_attributes }}>
       {{ content|without('field_alert_modified') }}
     </div>

--- a/drupal/web/themes/custom/fsa/template/navigation/pager.html.twig
+++ b/drupal/web/themes/custom/fsa/template/navigation/pager.html.twig
@@ -1,0 +1,98 @@
+{#
+/**
+ * @file
+ * Theme override to display a pager.
+ *
+ * Available variables:
+ * - items: List of pager items.
+ *   The list is keyed by the following elements:
+ *   - first: Item for the first page; not present on the first page of results.
+ *   - previous: Item for the previous page; not present on the first page
+ *     of results.
+ *   - next: Item for the next page; not present on the last page of results.
+ *   - last: Item for the last page; not present on the last page of results.
+ *   - pages: List of pages, keyed by page number.
+ *   Sub-sub elements:
+ *   items.first, items.previous, items.next, items.last, and each item inside
+ *   items.pages contain the following elements:
+ *   - href: URL with appropriate query parameters for the item.
+ *   - attributes: A keyed list of HTML attributes for the item.
+ *   - text: The visible text used for the item link, such as "‹ Previous"
+ *     or "Next ›".
+ * - current: The page number of the current page.
+ * - ellipses: If there are more pages than the quantity allows, then an
+ *   ellipsis before or after the listed pages may be present.
+ *   - previous: Present if the currently visible list of pages does not start
+ *     at the first page.
+ *   - next: Present if the visible list of pages ends before the last page.
+ *
+ * @see template_preprocess_pager()
+ */
+#}
+{% if items %}
+  <nav class="pager" role="navigation" aria-labelledby="pagination-heading">
+    <h3 id="pagination-heading" class="visually-hidden">{{ 'Pagination'|t }}</h3>
+    <ul class="pager__items js-pager__items">
+      {# Print first item if we are not on the first page. #}
+      {% if items.first %}
+        <li class="pager__item pager__item--first">
+          <a href="{{ items.first.href }}" title="{{ 'Go to first page'|t }}"{{ items.first.attributes|without('href', 'title') }}>
+            <span class="visually-hidden">{{ 'First page'|t }}</span>
+            <span aria-hidden="true">{{ items.first.text|default('« First'|t) }}</span>
+          </a>
+        </li>
+      {% endif %}
+      {# Print previous item if we are not on the first page. #}
+      {% if items.previous %}
+        <li class="pager__item pager__item--previous">
+          <a href="{{ items.previous.href }}" title="{{ 'Go to previous page'|t }}" rel="prev"{{ items.previous.attributes|without('href', 'title', 'rel') }}>
+            <span class="visually-hidden">{{ 'Previous page'|t }}</span>
+            <span aria-hidden="true">{{ items.previous.text|default('‹ Previous'|t) }}</span>
+          </a>
+        </li>
+      {% endif %}
+      {# Add an ellipsis if there are further previous pages. #}
+      {% if ellipses.previous %}
+        <li class="pager__item pager__item--ellipsis" role="presentation">&hellip;</li>
+      {% endif %}
+      {# Now generate the actual pager piece. #}
+      {% for key, item in items.pages %}
+        <li class="pager__item{{ current == key ? ' is-active' : '' }}">
+          {% if current == key %}
+            {% set title = 'Current page'|t %}
+          {% else %}
+            {% set title = 'Go to page @key'|t({'@key': key}) %}
+          {% endif %}
+          <a href="{{ item.href }}" title="{{ title }}"{{ item.attributes|without('href', 'title') }}>
+            <span class="visually-hidden">
+              {{ current == key ? 'Current page'|t : 'Page'|t }}
+            </span>
+            {{- key -}}
+          </a>
+        </li>
+      {% endfor %}
+      {# Add an ellipsis if there are further next pages. #}
+      {% if ellipses.next %}
+        <li class="pager__item pager__item--ellipsis" role="presentation">&hellip;</li>
+      {% endif %}
+      {# Print next item if we are not on the last page. #}
+      {% if items.next %}
+        <li class="pager__item pager__item--next">
+          <a href="{{ items.next.href }}" title="{{ 'Go to next page'|t }}" rel="next"{{ items.next.attributes|without('href', 'title', 'rel') }}>
+            <span class="visually-hidden">{{ 'Next page'|t }}</span>
+            <span aria-hidden="true">{{ items.next.text|default('Next ›'|t) }}</span>
+          </a>
+        </li>
+      {% endif %}
+      {# Print last item if we are not on the last page. #}
+      {% if items.last %}
+        <li class="pager__item pager__item--last">
+          <a href="{{ items.last.href }}" title="{{ 'Go to last page'|t }}"{{ items.last.attributes|without('href', 'title') }}>
+            <span class="visually-hidden">{{ 'Last page'|t }}</span>
+            <span aria-hidden="true">{{ items.last.text|default('Last »'|t) }}</span>
+          </a>
+        </li>
+      {% endif %}
+    </ul>
+  </nav>
+{% endif %}


### PR DESCRIPTION
Includes multiple accessibility fixes and enhancements to global search.

- Skip to content is now before the hero region (global change!) which also includes important page content, especially in global search.
- Added aria-live region with search results summary so when the search view's AJAX request is done, new results summary is announced by the screen reader. This is both useful information and confirmation that a new search was done after changing filters or using pagination.
- Changed search page heading hierarchy: search view has a hidden h2 "Search results", result titles are h3.
- Search link tabs have a hidden heading and toolbar role for context.
- Removed repetitive hidden "Alert type" heading from alert search results.

To test: drush cim -y, drush cr. Remember that most of these (except skip to content) only have effect using a screen reader!