### PR TITLE
FSA-1027 - Webform submission edit form is simplified

### DIFF
--- a/drupal/sync/block.block.teamfinder_2.yml
+++ b/drupal/sync/block.block.teamfinder_2.yml
@@ -25,6 +25,6 @@ settings:
 visibility:
   request_path:
     id: request_path
-    pages: "/admin/structure/webform/manage/foreign_object/submission/*/edit\r\n/admin/structure/webform/manage/hygiene_practices/submission/*/edit\r\n/admin/structure/webform/manage/food_poisoning/submission/*/edit"
+    pages: "/admin/structure/webform/manage/foreign_object/submission/*/edit\r\n/admin/structure/webform/manage/poor_hygiene_practices/submission/*/edit\r\n/admin/structure/webform/manage/food_poisoning/submission/*/edit"
     negate: false
     context_mapping: {  }

--- a/drupal/sync/core.extension.yml
+++ b/drupal/sync/core.extension.yml
@@ -73,6 +73,7 @@ module:
   fsa_toc: 0
   fsa_topic_listing: 0
   fsa_translate: 0
+  fsa_webform: 0
   fsa_webform_validation: 0
   geolocation: 0
   google_tag: 0

--- a/drupal/sync/views.view.la_send_failures.yml
+++ b/drupal/sync/views.view.la_send_failures.yml
@@ -258,6 +258,57 @@ display:
           entity_type: webform_submission
           entity_field: completed
           plugin_id: field
+        operations:
+          id: operations
+          table: webform_submission
+          field: operations
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Operations
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          destination: true
+          entity_type: webform_submission
+          plugin_id: entity_operations
       filters:
         webform_submission_value:
           id: webform_submission_value

--- a/drupal/web/modules/custom/fsa_webform/fsa_webform.info.yml
+++ b/drupal/web/modules/custom/fsa_webform/fsa_webform.info.yml
@@ -1,0 +1,7 @@
+name: FSA Webform
+description: Adds support for custom webform features.
+type: module
+core: 8.x
+package: FSA
+dependencies:
+  - drupal:webform

--- a/drupal/web/modules/custom/fsa_webform/fsa_webform.module
+++ b/drupal/web/modules/custom/fsa_webform/fsa_webform.module
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * @file
+ * Adds custom webform functionality.
+ */
+
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Implements hook_form_alter().
+ *
+ * Adds a copy of "Save" button to webform submission edit form. Also removes
+ * Continue and Previous buttons from webform submission edit form where they
+ * make little sense.
+ *
+ * This simplifies the process of saving a webform submission entity without
+ * requiring to go through every webform page.
+ */
+function fsa_webform_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  // Target specific webforms.
+  $webform_ids = [
+    'foreign_object',
+    'poor_hygiene_practices',
+    'food_poisoning',
+  ];
+
+  if (isset($form['#webform_id']) && in_array($form['#webform_id'], $webform_ids)) {
+    $form_object = $form_state->getFormObject();
+    /** @var \Drupal\webform\WebformSubmissionInterface $webform_submission */
+    $webform_submission = $form_object->getEntity();
+
+    // Work only in edit context.
+    if (!$webform_submission->isNew()) {
+      // Only administrative roles are allowed to see the save button.
+      if ($update_permission = !empty(array_intersect(['fsa_admin', 'administrator'], \Drupal::currentUser()->getRoles()))) {
+        // Copy submit button into a new one.
+        $form['actions']['save'] = $form['actions']['submit'];
+        $form['actions']['save']['#access'] = $update_permission;
+
+        // Remove preview/wizard prev/next buttons when in edit context.
+        foreach (['preview_prev', 'wizard_prev', 'preview_next', 'wizard_next'] as $button_name) {
+          if (isset($form['actions'][$button_name])) {
+            $form['actions'][$button_name]['#access'] = FALSE;
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Ticket: https://wunder.atlassian.net/browse/FSA-1027

This change adds the following features:
- Module `fsa_webform` is added to provide various webform related features.
- `Save` button is added to webform submission edit form which allows administrators to easily save the form without going through the pages of the webform. 
- `Failed to send` view is updated with operation links which simplifies the overview of the listing.

Steps to review:
1. Run `drush cim -y` and `drush cr`
2. Go to `/admin/reports/send-to-la-failures` and see that `Edit` buttons are visible for submissions
3. Click on `Edit` and see that `Continue` or `Previous` are not visible and `Save` button is present
4. Find the email of a local authority and save the form; see that you are taken back to the list of submissions