### PR TITLE
Lando support is added

### DIFF
--- a/drupal/.lando.yml
+++ b/drupal/.lando.yml
@@ -1,0 +1,60 @@
+name: fsa
+recipe: drupal8
+
+compose:
+  - compose.yml
+
+config:
+  webroot: web
+  via: nginx
+  php: '7.1'
+  database: mariadb:10.1
+  xdebug: true
+  conf:
+    php: conf/php.ini
+
+tooling:
+  build.sh:
+    service: appserver
+    description: Execute build.sh
+    cmd:
+      - ./build.sh
+  codeception:
+    service: appserver
+    description: Run codeception
+    cmd:
+      - ./vendor/bin/codecept
+      - "--env=lando"
+
+services:
+  mailhog:
+    type: mailhog
+    hogfrom:
+      - appserver
+
+  appserver:
+    extras:
+      - "apt-get update -y"
+      - "apt-get install python-yaml -y"
+    overrides:
+      services:
+        environment:
+          WKV_SITE_ENV: lando
+          DB_PASS_DRUPAL: drupal8
+          DB_USER_DRUPAL: drupal8
+          DB_HOST_DRUPAL: database
+          DB_NAME_DRUPAL: drupal8
+
+  elasticsearch:
+    type: elasticsearch:5.5
+
+proxy:
+  mailhog:
+    - mail.lndo.site
+  elasticsearch:
+    - elasticsearch.lndo.site:9200
+
+events:
+  # Clear caches after a database import
+  post-db-import:
+    - appserver: cd $LANDO_WEBROOT && drush cr -y

--- a/drupal/conf/php.ini
+++ b/drupal/conf/php.ini
@@ -1,0 +1,48 @@
+[PHP]
+
+;;;;;;;;;;;;;;;
+; PHP Globals ;
+;;;;;;;;;;;;;;;
+
+short_open_tag = Off
+output_buffering = 4096
+allow_call_time_pass_reference = Off
+variables_order = "GPCS"
+request_order = "GP"
+register_long_arrays = Off
+register_argc_argv = Off
+magic_quotes_gpc = Off
+enable_dl = Off
+allow_url_fopen = On
+realpath_cache_size = "800K"
+realpath_cache_ttl = "86400"
+
+
+[Date]
+date.timezone = "UTC"
+
+;;;;;;;;;;;;;;;;;;;;;;
+;; PACKAGE SETTINGS ;;
+;;;;;;;;;;;;;;;;;;;;;;
+
+; Xdebug
+xdebug.max_nesting_level = 512
+xdebug.show_exception_trace = 0
+xdebug.collect_params = 0
+xdebug.remote_autostart = 1
+xdebug.remote_enable = 1
+xdebug.remote_port = 9000
+
+; Globals
+expose_php = on
+max_execution_time = 90
+max_input_time = 900
+max_input_vars = 10000
+memory_limit = 512M
+upload_max_filesize = 100M
+post_max_size = 100M
+error_reporting = E_ALL & ~E_DEPRECATED
+ignore_repeated_errors = on
+html_errors = off
+display_errors = on
+log_errors = on


### PR DESCRIPTION
This change enables developers to set up their environment with Lando.

Steps to review:
1. Run `lando start` within `drupal/`.
2. That's it.