### PR TITLE
FSA-902: enabled auto redirect

### DIFF
--- a/drupal/sync/redirect.settings.yml
+++ b/drupal/sync/redirect.settings.yml
@@ -1,4 +1,4 @@
-auto_redirect: false
+auto_redirect: true
 default_status_code: 301
 passthrough_querystring: true
 warning: false


### PR DESCRIPTION
By changing title url is also updated. To make sure that content is still available on site with old url, need to make redirects. This change make it happen automatically. 
Test node - https://fsa.dev.wunder.io/news-alerts/news/new-node-second-update
Is should be available also from https://fsa.dev.wunder.io/news-alerts/news/new-node and https://fsa.dev.wunder.io/news-alerts/news/new-node-update

Try to change title once more - edit node, change title to something else, save. Notice that URL it changed. And now try to access all above links that I posted in this comment - It will end up with the newest path. If You try to change back title as it was before, it will take care and will be created new redirect to latest path and old one will be removed as it already exists.

Approved by Sally.

Ticket - https://wunder.atlassian.net/browse/FSA-902