### PR TITLE
FSA-1035: Fix fatal error if field is empty

### DIFF
--- a/drupal/web/modules/custom/fsa_alerts_import/src/Plugin/Field/FieldFormatter/AlertPlainTextFormatter.php
+++ b/drupal/web/modules/custom/fsa_alerts_import/src/Plugin/Field/FieldFormatter/AlertPlainTextFormatter.php
@@ -21,8 +21,7 @@ class AlertPlainTextFormatter extends BasicStringFormatter {
   /**
    * {@inheritdoc}
    */
-  public function settingsSummary()
-  {
+  public function settingsSummary() {
     $summary = [];
     $summary[] = $this->t('Wraps HTML around the content of this field lines and adds "Allergen(s)" text.');
     return $summary;
@@ -38,7 +37,7 @@ class AlertPlainTextFormatter extends BasicStringFormatter {
       $formatted = [];
       $lines = explode(PHP_EOL, $item->value);
       $i = 0;
-        foreach ($lines as $line) {
+      foreach ($lines as $line) {
         // Remove unnecessary line-breaks and don't care about the empty lines.
         $line = preg_replace("/\r|\n/", '', $line);
         if (strlen($line) < 1) {
@@ -46,7 +45,8 @@ class AlertPlainTextFormatter extends BasicStringFormatter {
         }
         // If there is more then 1 line, first line should contain extra data.
         if (count($lines) > 1 && $i == 0) {
-          $formatted[] = '<p><b>'.$this->t('Allergen(s)').': </b>' . $line. '</p>';
+          $label = $this->t('Allergen(s)');
+          $formatted[] = '<p><b>' . $label . ': </b>' . $line . '</p>';
           $i++;
         }
         else {
@@ -62,7 +62,9 @@ class AlertPlainTextFormatter extends BasicStringFormatter {
         ];
       }
 
-      return $elements;
     }
+    return $elements;
+
   }
+
 }


### PR DESCRIPTION
This PR fixes the bug on alerts if an alert node has empty RiskStatement.

* Return something if field is empty - else will fail fatally
* Fix coding standards