### PR TITLE
FSA-981: Add subscription category and node date to the Notify template

### DIFF
--- a/drupal/web/modules/custom/fsa_notify/src/FsaNotifyMessage.php
+++ b/drupal/web/modules/custom/fsa_notify/src/FsaNotifyMessage.php
@@ -120,4 +120,68 @@ abstract class FsaNotifyMessage {
     return $message;
   }
 
+  /**
+   * Get node update timestamp to alerts.
+   *
+   * @param \Drupal\node\Entity\Node $node
+   *   The node object.
+   * @param string $format
+   *   Time display format.
+   *
+   * @return string
+   *   Formatted display of field_alert_modified, node creation time if the
+   *    field is empty.
+   */
+  public function alertModifiedDate(Node $node, $format = 'medium') {
+    if (isset($node->field_alert_modified->value)) {
+      $date = \Drupal::service('date.formatter')->format(strtotime($node->field_alert_modified->value), $format);
+    }
+    else {
+      // Get the node creation time.
+      $date = \Drupal::service('date.formatter')->format($node->getCreatedTime(), $format);
+    }
+    return $date;
+  }
+
+  /**
+   * Get alert subcription category from node.
+   *
+   * @param \Drupal\node\Entity\Node $node
+   *   The node object.
+   *
+   * @return string
+   *   The alert type/category of the node.
+   */
+  public function alertSubscriptionCategory(Node $node) {
+
+    if ($node->hasField('field_alert_type')) {
+      switch ($node->field_alert_type->value) {
+        case 'AA':
+          $category = t('Allergy alert');
+          break;
+
+        default:
+          $category = t('Food alert');
+      }
+    }
+    else {
+      switch ($node->getType()) {
+        case 'news':
+          $category = t('News update');
+          break;
+
+        case 'consultation':
+          $category = t('Consultation update');
+          break;
+
+        default:
+          // Default to whatever the node type machine name is.
+          $category = ucfirst($node->getType());
+      }
+
+    }
+
+    return $category;
+  }
+
 }

--- a/drupal/web/modules/custom/fsa_notify/src/FsaNotifyMessageDaily.php
+++ b/drupal/web/modules/custom/fsa_notify/src/FsaNotifyMessageDaily.php
@@ -46,14 +46,18 @@ class FsaNotifyMessageDaily extends FsaNotifyMessage {
       $item = $item->getTranslation($lang);
     }
 
+    $category = self::alertSubscriptionCategory($item);
+    $date = self::alertModifiedDate($item);
+    $line1 = sprintf('%s %s:', $category, $date);
+
     $title = $item->getTitle();
-    $line1 = sprintf('%s', $title);
+    $line2 = $title;
 
     $link = $this->url($item, $lang);
     $more = t('Read more');
-    $line2 = sprintf('%s: %s', $more, $link);
+    $line3 = sprintf('%s: %s', $more, $link);
 
-    $item = "$line1\n$line2\n";
+    $item = "$line1\n$line2\n$line3\n";
     return $item;
   }
 

--- a/drupal/web/modules/custom/fsa_notify/src/FsaNotifyMessageImmediate.php
+++ b/drupal/web/modules/custom/fsa_notify/src/FsaNotifyMessageImmediate.php
@@ -50,14 +50,18 @@ class FsaNotifyMessageImmediate extends FsaNotifyMessage {
       $item = $item->getTranslation($lang);
     }
 
+    $category = self::alertSubscriptionCategory($item);
+    $date = self::alertModifiedDate($item);
+    $line1 = sprintf('%s %s:', $category, $date);
+
     $title = $item->getTitle();
-    $line1 = sprintf('%s', $title);
+    $line2 = sprintf('%s', $title);
 
     $link = $this->url($item, $lang);
     $more = t('Read more');
-    $line2 = sprintf('%s: %s', $more, $link);
+    $line3 = sprintf('%s: %s', $more, $link);
 
-    $item = "$line1\n$line2\n";
+    $item = "$line1\n$line2\n$line3";
     return $item;
   }
 

--- a/drupal/web/modules/custom/fsa_notify/src/FsaNotifyMessageWeekly.php
+++ b/drupal/web/modules/custom/fsa_notify/src/FsaNotifyMessageWeekly.php
@@ -46,16 +46,18 @@ class FsaNotifyMessageWeekly extends FsaNotifyMessage {
       $item = $item->getTranslation($lang);
     }
 
+    $category = self::alertSubscriptionCategory($item);
+    $date = self::alertModifiedDate($item);
+    $line1 = sprintf('%s %s:', $category, $date);
+
     $title = $item->getTitle();
-    $created = $item->getCreatedTime();
-    $created = \Drupal::service('date.formatter')->format($created, 'medium');
-    $line1 = sprintf('%s: %s', $created, $title);
+    $line2 = $title;
 
     $link = $this->url($item, $lang);
     $more = t('Read more');
-    $line2 = sprintf('%s: %s', $more, $link);
+    $line3 = sprintf('%s: %s', $more, $link);
 
-    $item = "$line1\n$line2\n";
+    $item = "$line1\n$line2\n$line3\n";
     return $item;
   }
 


### PR DESCRIPTION
This PR modifies `alert_items` variable sent to Notify template by displaying the subscription category and node date within each alert entry for immediate, daily and weekly emails.