### PR TITLE
FSA-1044: Set wizard page name to url instead of index

### DIFF
--- a/drupal/sync/webform.webform.food_fraud_crime.yml
+++ b/drupal/sync/webform.webform.food_fraud_crime.yml
@@ -69,7 +69,7 @@ settings:
   wizard_start_label: ''
   wizard_confirmation: true
   wizard_confirmation_label: ''
-  wizard_track: index
+  wizard_track: name
   preview: 2
   preview_label: Summary
   preview_title: ''

--- a/drupal/sync/webform.webform.food_poisoning.yml
+++ b/drupal/sync/webform.webform.food_poisoning.yml
@@ -71,7 +71,7 @@ settings:
   wizard_start_label: ''
   wizard_confirmation: true
   wizard_confirmation_label: ''
-  wizard_track: index
+  wizard_track: name
   preview: 2
   preview_label: Summary
   preview_title: ''

--- a/drupal/sync/webform.webform.foreign_object.yml
+++ b/drupal/sync/webform.webform.foreign_object.yml
@@ -73,7 +73,7 @@ settings:
   wizard_start_label: ''
   wizard_confirmation: true
   wizard_confirmation_label: ''
-  wizard_track: index
+  wizard_track: name
   preview: 2
   preview_label: Summary
   preview_title: ''

--- a/drupal/sync/webform.webform.poor_hygiene_practices.yml
+++ b/drupal/sync/webform.webform.poor_hygiene_practices.yml
@@ -68,7 +68,7 @@ settings:
   wizard_start_label: ''
   wizard_confirmation: true
   wizard_confirmation_label: ''
-  wizard_track: index
+  wizard_track: name
   preview: 2
   preview_label: Summary
   preview_title: ''


### PR DESCRIPTION
PR changes the `?page` parameter in contact form webform wizerd pages to display the page name instead of index number