### PR TITLE
FSA-1036: Fix anonymous users 403 page from hero cta link

### DIFF
--- a/drupal/web/modules/custom/fsa_alerts/src/FsaAlertsHelper.php
+++ b/drupal/web/modules/custom/fsa_alerts/src/FsaAlertsHelper.php
@@ -22,11 +22,19 @@ class FsaAlertsHelper {
    */
   public static function ctaSubscribe() {
 
-    $text = t('Subscribe to news and alerts');
+    if (\Drupal::currentUser()->isAuthenticated()) {
+      $text = t('Manage your subscription');
+      $route = 'fsa_signin.user_preregistration_alerts_form';
+    }
+    else {
+      $text = t('Subscribe to news and alerts');
+      $route = 'fsa_signin.default_controller_signInPage';
+    }
+
     $options = ['attributes' => ['class' => 'button']];
 
     try {
-      $cta = Link::createFromRoute($text, 'fsa_signin.user_preregistration_alerts_form', [], $options);
+      $cta = Link::createFromRoute($text, $route, [], $options);
     }
     catch (\Exception $e) {
       // In case the link creation when route was non-existent.


### PR DESCRIPTION
PR fixes the 403 CTA link for anonymous users on https://www.food.gov.uk/news-alerts hero area.

* Logged in get "Manage your subscription" `/profile/manage` page
* Anonymous see "Subscribe to news and alerts" link to `/news-alerts/signin` page