### PR TITLE
Fix taxonomy_term storage failure when setting up new local instance

### DIFF
--- a/drupal/web/modules/custom/fsa_consultations/fsa_consultations.install
+++ b/drupal/web/modules/custom/fsa_consultations/fsa_consultations.install
@@ -12,29 +12,34 @@ use Drupal\taxonomy\Entity\Term;
  */
 function fsa_consultations_install() {
 
-  // Add few terms to consultation type on install (if vocab is empty).
-  $vid = 'consultations_type';
-  $vocab = \Drupal::service('entity_type.manager')
-    ->getStorage('taxonomy_term')
-    ->loadTree($vid);
+  /* @var $entity_type_manager \Drupal\Core\Entity\EntityTypeManagerInterface */
+  $entity_type_manager = \Drupal::service('entity_type.manager');
 
-  if (empty($vocab)) {
-    // Term names to be added.
-    $items = [
-      'Consultation',
-      'Help shape our policies',
-      'Rapidly developing policies',
-    ];
+  if ($entity_type_manager->hasDefinition('taxonomy_term')) {
+    // Add few terms to consultation type on install (if vocab is empty).
+    $vid = 'consultations_type';
+    $vocab = $entity_type_manager
+      ->getStorage('taxonomy_term')
+      ->loadTree($vid);
 
-    foreach ($items as $item) {
-      $term = Term::create([
-        'parent' => [],
-        'name' => $item,
-        'vid' => $vid,
-      ])->save();
+    if (empty($vocab)) {
+      // Term names to be added.
+      $items = [
+        'Consultation',
+        'Help shape our policies',
+        'Rapidly developing policies',
+      ];
 
-      if ($term) {
-        drupal_set_message('Created term ' . $item);
+      foreach ($items as $item) {
+        $term = Term::create([
+          'parent' => [],
+          'name' => $item,
+          'vid' => $vid,
+        ])->save();
+
+        if ($term) {
+          drupal_set_message('Created term ' . $item);
+        }
       }
     }
   }


### PR DESCRIPTION
This PR attempts to fix the issue with spinning up new local environment failure on getting the taxonomy_term storage that does not exist yet.