### PR TITLE
Fix fatal error on revision pages

### DIFF
--- a/drupal/web/modules/custom/fsa_contactus/fsa_contactus.module
+++ b/drupal/web/modules/custom/fsa_contactus/fsa_contactus.module
@@ -8,6 +8,7 @@
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\fsa_custom\FsaCustomHelper;
 use Drupal\block\Entity\Block;
+use Drupal\node\NodeInterface;
 
 /**
  * Implements hook_webform_element_alter().
@@ -125,7 +126,7 @@ function fsa_contactus_preprocess_page(array &$variables) {
   /* @var $route_name = \Symfony\Component\Routing\Route\routeMatch() */
   $route = \Drupal::routeMatch();
 
-  if (isset($variables['node']) && $variables['node']->hasField('webform')) {
+  if (isset($variables['node']) && $variables['node'] instanceof NodeInterface && $variables['node']->hasField('webform')) {
     // Webforms id's we want the user satisfaction form to be attached to.
     $webform_ids = [
       'foreign_object',


### PR DESCRIPTION
This PR fixes e.g. `/node/NID/revisions/RID/view` paths failing on fatal error because of insufficient check of the assumed node object. Bug exists on production too.