### PR TITLE
FSA-1079: RSS feeds error 404 in links

### DIFF
--- a/drupal/composer.json
+++ b/drupal/composer.json
@@ -110,7 +110,8 @@
         "patches": {
             "drupal/core": {
                 "Combination of language negotiation and path aliasing can cause a corrupted route cache, 404s": "https://www.drupal.org/files/issues/routing-cache-language-2802403-214.patch",
-                "Fix exporting of new_revision when content moderation is enabled": "https://www.drupal.org/files/issues/2865223-7.patch"
+                "Fix exporting of new_revision when content moderation is enabled": "https://www.drupal.org/files/issues/2865223-7.patch",
+                "RSS view with fields give wrong URL from path field": "https://www.drupal.org/files/issues/2018-04-20/2673980-36.patch"
             },
             "drupal/migrate_plus": {
                 "Allow setting request headers": "https://www.drupal.org/files/issues/fix_headers-2849153-3.patch"


### PR DESCRIPTION
[Patches](https://www.drupal.org/project/drupal/issues/2673980#comment-12581620) Drupal core to fix the RSS view fields giving wrong URL from path field.

To test see feeds on dev and `<link>` tags should have full working link urls.
https://fsa.dev.wunder.io/rss-feed/alerts
https://fsa.dev.wunder.io/rss-feed/alerts-allergy
https://fsa.dev.wunder.io/rss-feed/alerts-food
https://fsa.dev.wunder.io/rss-feed/news
https://fsa.dev.wunder.io/rss-feed/news-ni
https://fsa.dev.wunder.io/rss-feed/news-wales