### PR TITLE
FSA-1082: Allow large webform results file to be downloaded

### DIFF
--- a/conf/variables.yml
+++ b/conf/variables.yml
@@ -34,6 +34,12 @@ drush: {
 drush_use_launcher: False
 php_env_vars_include_db: True
 
+nginx_drupal_override_locations:
+  - operator: "~*"
+    condition: "^/admin/structure/webform/manage/(.*)/results/download/file/(.*).+\\.(?:csv?)$"
+    action: |
+      try_files $uri @drupal;
+
 firewall_web_whitelist_enabled: true
 
 # Variables to create/update UpCloud Servers


### PR DESCRIPTION
nginx serves 404 for non-existing .csv files thus prevents generating csv export of webform results at `/admin/structure/webform` -> form -> download.

This PR adds a directive to allow such webform .csv download requests to be passed for Drupal. Requires provisioning to production.