### PR TITLE
Feature/fsa 1078 moderation state fix

### DIFF
--- a/drupal/web/modules/custom/fsa_workflows/fsa_workflows.module
+++ b/drupal/web/modules/custom/fsa_workflows/fsa_workflows.module
@@ -46,6 +46,7 @@ function fsa_workflows_form_alter(&$form, FormStateInterface $form_state, $form_
       $path_args = explode('/', $current_path);
       if ($form_state->getFormObject()->getEntity()->get('default_langcode')->value == FALSE && $path_args[1]=='node' && is_numeric($path_args[2]) && $path_args[3]=='translations') {
         // New translations should always be drafts, instead of copying the original language's moderation state.
+        $form['moderation_state']['widget'][0]['current']['#markup'] = 'Draft';
         $form['moderation_state']['widget'][0]['state']['#default_value'] = 'draft';
       }
     }

--- a/drupal/web/modules/custom/fsa_workflows/fsa_workflows.module
+++ b/drupal/web/modules/custom/fsa_workflows/fsa_workflows.module
@@ -44,7 +44,7 @@ function fsa_workflows_form_alter(&$form, FormStateInterface $form_state, $form_
       // Check if we're creating a new translation.
       $current_path = \Drupal::service('path.current')->getPath();
       $path_args = explode('/', $current_path);
-      if ($form_state->getFormObject()->getEntity()->get('default_langcode')->value == FALSE && $path_args[1]=='node' && is_numeric($path_args[2]) && $path_args[3]=='translations') {
+      if ($form_state->getFormObject()->getEntity()->get('default_langcode')->value == FALSE && $path_args[1] == 'node' && is_numeric($path_args[2]) && $path_args[3] == 'translations') {
         // New translations should always be drafts, instead of copying the original language's moderation state.
         $form['moderation_state']['widget'][0]['current']['#markup'] = 'Draft';
         $form['moderation_state']['widget'][0]['state']['#default_value'] = 'draft';

--- a/drupal/web/modules/custom/fsa_workflows/fsa_workflows.module
+++ b/drupal/web/modules/custom/fsa_workflows/fsa_workflows.module
@@ -41,13 +41,17 @@ function fsa_workflows_form_alter(&$form, FormStateInterface $form_state, $form_
     $node = \Drupal::routeMatch()->getParameter('node');
 
     if ($node instanceof NodeInterface && $moderation_information->isModeratedEntity($node) && $moderation_information->isDefaultRevisionPublished($node)) {
-      // Check if we're creating a new translation.
-      $current_path = \Drupal::service('path.current')->getPath();
-      $path_args = explode('/', $current_path);
-      if ($form_state->getFormObject()->getEntity()->get('default_langcode')->value == FALSE && $path_args[1] == 'node' && is_numeric($path_args[2]) && $path_args[3] == 'translations') {
-        // New translations should always be drafts, instead of copying the original language's moderation state.
-        $form['moderation_state']['widget'][0]['current']['#markup'] = 'Draft';
-        $form['moderation_state']['widget'][0]['state']['#default_value'] = 'draft';
+      if ($form_state->getFormObject()->getEntity()->get('default_langcode')->value == FALSE) {
+        // Check if we're creating a new translation.
+        $current_path = \Drupal::service('path.current')->getPath();
+        $path_args = explode('/', $current_path);
+        if (count($path_args) > 4) {
+          if ($path_args[1] == 'node' && is_numeric($path_args[2]) && $path_args[3] == 'translations') {
+            // New translations should always be drafts, instead of copying the original language's moderation state.
+            $form['moderation_state']['widget'][0]['current']['#markup'] = 'Draft';
+            $form['moderation_state']['widget'][0]['state']['#default_value'] = 'draft';
+          }
+        }
       }
     }
   }

--- a/drupal/web/modules/custom/fsa_workflows/fsa_workflows.module
+++ b/drupal/web/modules/custom/fsa_workflows/fsa_workflows.module
@@ -41,12 +41,12 @@ function fsa_workflows_form_alter(&$form, FormStateInterface $form_state, $form_
     $node = \Drupal::routeMatch()->getParameter('node');
 
     if ($node instanceof NodeInterface && $moderation_information->isModeratedEntity($node) && $moderation_information->isDefaultRevisionPublished($node)) {
-      // Check if we're creating a translation.
-      if ($form_state->getFormObject()->getEntity()->get('default_langcode')->value == FALSE) {
+      // Check if we're creating a new translation.
+      $current_path = \Drupal::service('path.current')->getPath();
+      $path_args = explode('/', $current_path);
+      if ($form_state->getFormObject()->getEntity()->get('default_langcode')->value == FALSE && $path_args[1]=='node' && is_numeric($path_args[2]) && $path_args[3]=='translations') {
+        // New translations should always be drafts, instead of copying the original language's moderation state.
         $form['moderation_state']['widget'][0]['state']['#default_value'] = 'draft';
-      }
-      else {
-        $form['moderation_state']['widget'][0]['state']['#default_value'] = 'published';
       }
     }
   }


### PR DESCRIPTION
1) All new nodes and translations should have their state field set as 'draft' by default.
2) When editing existing nodes and translations the state field should remain the same. E.g. editing a 'ready for review' node should mean the field is set to 'ready for review'.
3) When creating a new translation for an existing English page, the 'current state' should say draft.

ACTION >DEFAULT STATE
Create a new node > Draft
Edit published node > Published
Edit draft node > Draft
Edit a review node > Ready for review
Create a new translation > Draft
Edit a translation draft > Draft
Edit a translation review > Ready for review
Edit a published translation > Published