### PR TITLE
Housekeeping: config readonly whitelist patterns

### DIFF
--- a/drupal/composer.lock
+++ b/drupal/composer.lock
@@ -1943,17 +1943,17 @@
         },
         {
             "name": "drupal/config_readonly",
-            "version": "1.0.0-beta2",
+            "version": "1.0.0-beta3",
             "source": {
                 "type": "git",
                 "url": "https://git.drupal.org/project/config_readonly",
-                "reference": "8.x-1.0-beta2"
+                "reference": "8.x-1.0-beta3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/config_readonly-8.x-1.0-beta2.zip",
-                "reference": "8.x-1.0-beta2",
-                "shasum": "d3309a69ee9950a3e696a407981673ce5b041a16"
+                "url": "https://ftp.drupal.org/files/projects/config_readonly-8.x-1.0-beta3.zip",
+                "reference": "8.x-1.0-beta3",
+                "shasum": "ef474bcf5f46221e88b1cf4fa2b6abe99439b878"
             },
             "require": {
                 "drupal/core": "~8.0"
@@ -1964,8 +1964,8 @@
                     "dev-1.x": "1.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-1.0-beta2",
-                    "datestamp": "1453962636",
+                    "version": "8.x-1.0-beta3",
+                    "datestamp": "1519398184",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Project has not opted into security advisory coverage!"
@@ -1974,7 +1974,7 @@
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0+"
+                "GPL-2.0-or-later"
             ],
             "authors": [
                 {

--- a/drupal/web/sites/default/settings.php
+++ b/drupal/web/sites/default/settings.php
@@ -71,6 +71,11 @@ $settings['config_readonly_whitelist_patterns'] = [
   'force_password_change.settings',
 ];
 
+// Allow configuration changes via drush (command line).
+if (PHP_SAPI === 'cli') {
+  $settings['config_readonly'] = FALSE;
+}
+
 // Be sure to have config_split.dev disabled by default.
 $config['config_split.config_split.dev']['status'] = FALSE;
 

--- a/drupal/web/sites/default/settings.php
+++ b/drupal/web/sites/default/settings.php
@@ -60,39 +60,16 @@ if(!empty($_SERVER['SERVER_ADDR'])){
 // Disallow configuration changes by default.
 $settings['config_readonly'] = TRUE;
 
-// Define specific admin pages to allow configuration changes on production.
-// @todo: follow issue https://www.drupal.org/node/2826274 for a fix on this.
-$config_allowed = [
-  '/admin/structure/menu/manage/account',
-  '/admin/structure/menu/manage/main',
-  '/admin/structure/menu/manage/help',
-  '/admin/structure/menu/manage/footer',
-  '/admin/config/system/site-information',
-  '/admin/config/fsa/ratings',
-  '/admin/config/fsa/ratings/translate/cy/add',
-  '/admin/config/fsa/ratings/translate/cy/edit',
-  '/admin/config/fsa/consultations',
-  '/admin/config/fsa/consultations/translate/cy/add',
-  '/admin/config/fsa/consultations/translate/cy/edit',
-  '/admin/config/content/embed/button/manage/document',
-  '/admin/config/content/embed/button/manage/media_entity_embed',
-  '/admin/config/content/embed/button/manage/image',
-  '/admin/config/content/embed/button/manage/node',
-  '/admin/config/people/force_password_change',
+// The config names that are allowed to be changed in readonly environments.
+$settings['config_readonly_whitelist_patterns'] = [
+  'system.site',
+  'system.menu.*',
+  'system.performance',
+  'core.menu.static_menu_link_overrides',
+  'config.fsa_ratings',
+  'config.fsa_consultations',
+  'force_password_change.settings',
 ];
-
-// Allow config changes on specified path pattern and command line.
-if (in_array($_SERVER['REQUEST_URI'], $config_allowed) || PHP_SAPI === 'cli') {
-  $settings['config_readonly'] = FALSE;
-}
-
-// We want to sometimes manage webforms on staging, temporarily allow config
-// changes here.
-/*
-if (strpos($_SERVER['REQUEST_URI'], '/admin/structure/webform/manage') === 0) {
-  $settings['config_readonly'] = FALSE;
-}
-*/
 
 // Be sure to have config_split.dev disabled by default.
 $config['config_split.config_split.dev']['status'] = FALSE;


### PR DESCRIPTION
This PR:

* Updates config_readonly to latest beta
* Changes to `config_readonly_whitelist_patterns` setting instead of hacky/unreliable admin path checking for configurations that should be allowed to save in remote environments

To test locally: 
* Add `$settings['config_readonly'] = TRUE;` to `drupal/conf/settings.private.php` (or temporarily uncomment the respective line from `settings.php:L138`)
* Ensure the required configurations can be saved
* Ensure that other configurations forms do not allow changes