### PR TITLE
Feature/fsa 1070 required translations

### DIFF
--- a/drupal/sync/config.fsa_translate.yml
+++ b/drupal/sync/config.fsa_translate.yml
@@ -1,3 +1,3 @@
 translation_required_mail_recipient: welsh.language.translation.unit@food.gov.uk
-translation_required_mail_subject: 'Translation required'
-translation_required_mail_body: "<p>Draft content <strong>[node:title]</strong> has been flagged as requiring translation at [site:url-brief].</p>\r\n\r\n<ul>\r\n\t<li>Edit: [node:edit-url]</li>\r\n>Draft content <strong>[node:title]</strong> has been flagged\r\n</ul>\r\n"
+translation_required_mail_subject: 'Content requires translation [site:url-brief]'
+translation_required_mail_body: '<p>Content [node:title] requires translation.</p><ul><li>Edit: [node:edit-url]</li><li>Latest revision: [site:url]node/[node:nid]/revisions/[node:vid]/view</li><li>Revision log message: [node:log]</li></ul>'

--- a/drupal/sync/config.fsa_translate.yml
+++ b/drupal/sync/config.fsa_translate.yml
@@ -1,3 +1,3 @@
 translation_required_mail_recipient: fsa.communications@food.gov.uk
 translation_required_mail_subject: 'Translation required'
-translation_required_mail_body: "<p>Draft content <strong>[node:title]</strong> has been flagged as requiring translation at [site:url-brief].</p>\r\n\r\n<ul>\r\n\t<li>Edit: [node:edit-url]</li>\r\n</ul>\r\n"
+translation_required_mail_body: "<p>Draft content <strong>[node:title]</strong> has been flagged as requiring translation at [site:url-brief].</p>\r\n\r\n<ul>\r\n\t<li>Edit: [node:edit-url]</li>\r\n>Draft content <strong>[node:title]</strong> has been flagged\r\n</ul>\r\n"

--- a/drupal/sync/config.fsa_translate.yml
+++ b/drupal/sync/config.fsa_translate.yml
@@ -1,0 +1,3 @@
+translation_required_mail_recipient: john.durance@wunder.io
+translation_required_mail_subject: 'Translation required'
+translation_required_mail_body: "<p>Draft content <strong>[node:title]</strong> has been flagged as requiring translation at [site:url-brief].</p>\r\n\r\n<ul>\r\n\t<li>Edit: [node:edit-url]</li>\r\n</ul>\r\n"

--- a/drupal/sync/config.fsa_translate.yml
+++ b/drupal/sync/config.fsa_translate.yml
@@ -1,3 +1,3 @@
-translation_required_mail_recipient: fsa.communications@food.gov.uk
+translation_required_mail_recipient: welsh.language.translation.unit@food.gov.uk
 translation_required_mail_subject: 'Translation required'
 translation_required_mail_body: "<p>Draft content <strong>[node:title]</strong> has been flagged as requiring translation at [site:url-brief].</p>\r\n\r\n<ul>\r\n\t<li>Edit: [node:edit-url]</li>\r\n>Draft content <strong>[node:title]</strong> has been flagged\r\n</ul>\r\n"

--- a/drupal/sync/config.fsa_translate.yml
+++ b/drupal/sync/config.fsa_translate.yml
@@ -1,3 +1,3 @@
-translation_required_mail_recipient: john.durance@wunder.io
+translation_required_mail_recipient: fsa.communications@food.gov.uk
 translation_required_mail_subject: 'Translation required'
 translation_required_mail_body: "<p>Draft content <strong>[node:title]</strong> has been flagged as requiring translation at [site:url-brief].</p>\r\n\r\n<ul>\r\n\t<li>Edit: [node:edit-url]</li>\r\n</ul>\r\n"

--- a/drupal/sync/core.extension.yml
+++ b/drupal/sync/core.extension.yml
@@ -74,6 +74,7 @@ module:
   fsa_team_finder: 0
   fsa_toc: 0
   fsa_topic_listing: 0
+  fsa_translate: 0
   fsa_webform: 0
   fsa_webform_validation: 0
   fsa_workflows: 0

--- a/drupal/sync/views.view.translations_required.yml
+++ b/drupal/sync/views.view.translations_required.yml
@@ -1,0 +1,392 @@
+uuid: a91665b1-b725-448c-9eec-6727e68d1e7b
+langcode: en
+status: true
+dependencies:
+  module:
+    - fsa_translate
+    - node
+    - user
+id: translations_required
+label: 'Translations required'
+module: views
+description: ''
+tag: ''
+base_table: fsa_translation_required
+base_field: ''
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'administer nodes'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: full
+        options:
+          items_per_page: 10
+          offset: 0
+          id: 0
+          total_pages: null
+          tags:
+            previous: ‹‹
+            next: ››
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          override: true
+          sticky: false
+          caption: ''
+          summary: ''
+          description: ''
+          columns:
+            translation_required: translation_required
+          info:
+            translation_required:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          default: '-1'
+          empty_table: false
+      row:
+        type: fields
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: nid
+          group_type: group
+          admin_label: ''
+          label: Title
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+        uid:
+          id: uid
+          table: node_field_data
+          field: uid
+          relationship: nid
+          group_type: group
+          admin_label: ''
+          label: 'Created by'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: uid
+          plugin_id: field
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          relationship: nid
+          group_type: group
+          admin_label: ''
+          label: Created
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: medium
+            custom_date_format: ''
+            timezone: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: created
+          plugin_id: field
+      filters:
+        translation_required:
+          id: translation_required
+          table: fsa_translation_required
+          field: translation_required
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: boolean
+      sorts: {  }
+      title: 'Translations required'
+      header: {  }
+      footer: {  }
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content:
+            value: 'Nothing to translate'
+            format: full_html
+          plugin_id: text
+      relationships:
+        nid:
+          id: nid
+          table: fsa_translation_required
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: 'Translation required'
+          required: false
+          plugin_id: standard
+      arguments: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - user.permissions
+      tags: {  }
+  page_1:
+    display_plugin: page
+    id: page_1
+    display_title: Page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: admin/content/translations
+      menu:
+        type: tab
+        title: 'Translation required'
+        description: ''
+        expanded: false
+        parent: ''
+        weight: -9
+        context: '0'
+        menu_name: main
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - user.permissions
+      tags: {  }

--- a/drupal/web/modules/custom/fsa_translate/config/install/fsa_translate.settings.yml
+++ b/drupal/web/modules/custom/fsa_translate/config/install/fsa_translate.settings.yml
@@ -1,0 +1,3 @@
+translation_required_mail_recipient: welsh.language.translation.unit@food.gov.uk
+translation_required_mail_subject: 'Content requires translation [site:url-brief]'
+translation_required_mail_body: '<p>Content [node:title] requires translation.</p><ul><li>Edit: [node:edit-url]</li><li>Latest revision: [site:url]node/[node:nid]/revisions/[node:vid]/view</li><li>Revision log message: [node:log]</li></ul>'

--- a/drupal/web/modules/custom/fsa_translate/config/install/fsa_translate.settings.yml
+++ b/drupal/web/modules/custom/fsa_translate/config/install/fsa_translate.settings.yml
@@ -1,3 +1,3 @@
-translation_required_mail_recipient: fsa.communications@food.gov.uk
+translation_required_mail_recipient: welsh.language.translation.unit@food.gov.uk
 translation_required_mail_subject: 'Translation required'
 translation_required_mail_body: '<p>Draft content <strong>[node:title]</strong> has been flagged as requiring translation at [site:url-brief].</p><ul><li>Edit: [node:edit-url]</li>>Draft content <strong>[node:title]</strong> has been flagged</ul>'

--- a/drupal/web/modules/custom/fsa_translate/config/install/fsa_translate.settings.yml
+++ b/drupal/web/modules/custom/fsa_translate/config/install/fsa_translate.settings.yml
@@ -1,3 +1,0 @@
-translation_required_mail_recipient: welsh.language.translation.unit@food.gov.uk
-translation_required_mail_subject: 'Translation required'
-translation_required_mail_body: '<p>Draft content <strong>[node:title]</strong> has been flagged as requiring translation at [site:url-brief].</p><ul><li>Edit: [node:edit-url]</li>>Draft content <strong>[node:title]</strong> has been flagged</ul>'

--- a/drupal/web/modules/custom/fsa_translate/config/install/fsa_translate.settings.yml
+++ b/drupal/web/modules/custom/fsa_translate/config/install/fsa_translate.settings.yml
@@ -1,3 +1,3 @@
 translation_required_mail_recipient: fsa.communications@food.gov.uk
 translation_required_mail_subject: 'Translation required'
-translation_required_mail_body: '<p>Draft content <strong>[node:title]</strong> has been flagged as requiring translation at [site:url-brief].</p><ul><li>Edit: [node:edit-url]</li></ul>'
+translation_required_mail_body: '<p>Draft content <strong>[node:title]</strong> has been flagged as requiring translation at [site:url-brief].</p><ul><li>Edit: [node:edit-url]</li>>Draft content <strong>[node:title]</strong> has been flagged</ul>'

--- a/drupal/web/modules/custom/fsa_translate/config/install/fsa_translate.settings.yml
+++ b/drupal/web/modules/custom/fsa_translate/config/install/fsa_translate.settings.yml
@@ -1,0 +1,3 @@
+translation_required_mail_recipient: fsa.communications@food.gov.uk
+translation_required_mail_subject: 'Translation required'
+translation_required_mail_body: '<p>Draft content <strong>[node:title]</strong> has been flagged as requiring translation at [site:url-brief].</p><ul><li>Edit: [node:edit-url]</li></ul>'

--- a/drupal/web/modules/custom/fsa_translate/fsa_translate.info.yml
+++ b/drupal/web/modules/custom/fsa_translate/fsa_translate.info.yml
@@ -1,5 +1,5 @@
 name: FSA translate
-description: Alters default translation settings. This was deprecated and uninstalled within FSA-997. Left in codebase for if we want to later take in use for translations workflow.
+description: Enables content translation management.
 package: FSA
 type: module
 core: 8.x

--- a/drupal/web/modules/custom/fsa_translate/fsa_translate.install
+++ b/drupal/web/modules/custom/fsa_translate/fsa_translate.install
@@ -58,35 +58,7 @@ function fsa_translate_update_8001(&$sandbox) {
 /**
  * Implements hook_update_N().
  */
-function fsa_translate_update_8002() {
-
-  // Default translation required configuration.
-  $config_factory = \Drupal::configFactory();
-  $config = $config_factory->getEditable('config.fsa_translate');
-  $config->set('translation_required_mail_recipient', 'fsa.communications@food.gov.uk');
-  $config->set('translation_required_mail_subject', 'Translation required');
-  $config->set('translation_required_mail_body', '<p>Draft content <strong>[node:title]</strong> has been flagged as requiring translation at [site:url-brief].</p><ul><li>Edit: [node:edit-url]</li><li>Revisions: [site:url]/node/[node:nid]/revisions</li></ul>');
-  $config->save(TRUE);
-}
-
-/**
- * Implements hook_update_N().
- */
-function fsa_translate_update_8003() {
-
-  // Default translation required configuration.
-  $config_factory = \Drupal::configFactory();
-  $config = $config_factory->getEditable('config.fsa_translate');
-  $config->set('translation_required_mail_recipient', 'welsh.language.translation.unit@food.gov.uk');
-  $config->set('translation_required_mail_subject', 'Translation required');
-  $config->set('translation_required_mail_body', '<p>Draft content <strong>[node:title]</strong> has been flagged as requiring translation at [site:url-brief].</p><ul><li>Edit: [node:edit-url]</li><li>Revisions: [site:url]/node/[node:nid]/revisions</li></ul>');
-  $config->save(TRUE);
-}
-
-/**
- * Implements hook_update_N().
- */
-function fsa_translate_update_8004() {
+function fsa_translate_update_8010() {
 
   // Default translation required configuration.
   $config_factory = \Drupal::configFactory();

--- a/drupal/web/modules/custom/fsa_translate/fsa_translate.install
+++ b/drupal/web/modules/custom/fsa_translate/fsa_translate.install
@@ -65,7 +65,7 @@ function fsa_translate_update_8002() {
   $config = $config_factory->getEditable('config.fsa_translate');
   $config->set('translation_required_mail_recipient', 'fsa.communications@food.gov.uk');
   $config->set('translation_required_mail_subject', 'Translation required');
-  $config->set('translation_required_mail_body', '<p>Draft content <strong>[node:title]</strong> has been flagged as requiring translation at [site:url-brief].</p><ul><li>Edit: [node:edit-url]</li></ul>');
+  $config->set('translation_required_mail_body', '<p>Draft content <strong>[node:title]</strong> has been flagged as requiring translation at [site:url-brief].</p><ul><li>Edit: [node:edit-url]</li><li>Revisions: [site:url]/node/[node:nid]/revisions</li></ul>');
   $config->save(TRUE);
 }
 

--- a/drupal/web/modules/custom/fsa_translate/fsa_translate.install
+++ b/drupal/web/modules/custom/fsa_translate/fsa_translate.install
@@ -70,6 +70,20 @@ function fsa_translate_update_8002() {
 }
 
 /**
+ * Implements hook_update_N().
+ */
+function fsa_translate_update_8003() {
+
+  // Default translation required configuration.
+  $config_factory = \Drupal::configFactory();
+  $config = $config_factory->getEditable('config.fsa_translate');
+  $config->set('translation_required_mail_recipient', 'welsh.language.translation.unit@food.gov.uk');
+  $config->set('translation_required_mail_subject', 'Translation required');
+  $config->set('translation_required_mail_body', '<p>Draft content <strong>[node:title]</strong> has been flagged as requiring translation at [site:url-brief].</p><ul><li>Edit: [node:edit-url]</li><li>Revisions: [site:url]/node/[node:nid]/revisions</li></ul>');
+  $config->save(TRUE);
+}
+
+/**
  * Implements hook_uninstall().
  */
 function fsa_translate_uninstall_schema() {

--- a/drupal/web/modules/custom/fsa_translate/fsa_translate.install
+++ b/drupal/web/modules/custom/fsa_translate/fsa_translate.install
@@ -84,6 +84,20 @@ function fsa_translate_update_8003() {
 }
 
 /**
+ * Implements hook_update_N().
+ */
+function fsa_translate_update_8004() {
+
+  // Default translation required configuration.
+  $config_factory = \Drupal::configFactory();
+  $config = $config_factory->getEditable('config.fsa_translate');
+  $config->set('translation_required_mail_recipient', 'welsh.language.translation.unit@food.gov.uk');
+  $config->set('translation_required_mail_subject', 'Content requires translation [site:url-brief]');
+  $config->set('translation_required_mail_body', '<p>Content [node:title] requires translation.</p><ul><li>Edit: [node:edit-url]</li><li>Latest revision: [site:url]node/[node:nid]/revisions/[node:vid]/view</li><li>Revision log message: [node:log]</li></ul>');
+  $config->save(TRUE);
+}
+
+/**
  * Implements hook_uninstall().
  */
 function fsa_translate_uninstall_schema() {

--- a/drupal/web/modules/custom/fsa_translate/fsa_translate.install
+++ b/drupal/web/modules/custom/fsa_translate/fsa_translate.install
@@ -56,6 +56,20 @@ function fsa_translate_update_8001(&$sandbox) {
 }
 
 /**
+ * Implements hook_update_N().
+ */
+function fsa_translate_update_8002() {
+
+  // Default translation required configuration.
+  $config_factory = \Drupal::configFactory();
+  $config = $config_factory->getEditable('config.fsa_translate');
+  $config->set('translation_required_mail_recipient', 'fsa.communications@food.gov.uk');
+  $config->set('translation_required_mail_subject', 'Translation required');
+  $config->set('translation_required_mail_body', '<p>Draft content <strong>[node:title]</strong> has been flagged as requiring translation at [site:url-brief].</p><ul><li>Edit: [node:edit-url]</li></ul>');
+  $config->save(TRUE);
+}
+
+/**
  * Implements hook_uninstall().
  */
 function fsa_translate_uninstall_schema() {

--- a/drupal/web/modules/custom/fsa_translate/fsa_translate.links.menu.yml
+++ b/drupal/web/modules/custom/fsa_translate/fsa_translate.links.menu.yml
@@ -1,0 +1,5 @@
+fsa_translate.translation_required_configuration:
+  title: 'Translation required'
+  parent: system.admin_config_fsa
+  description: 'Translation required configuration.'
+  route_name: fsa_translate.translation_required_configuration

--- a/drupal/web/modules/custom/fsa_translate/fsa_translate.module
+++ b/drupal/web/modules/custom/fsa_translate/fsa_translate.module
@@ -27,12 +27,12 @@ function fsa_translate_form_node_form_alter(&$form, FormStateInterface $form_sta
   // Add entity meta details.
   $form['translation'] = [
     '#type' => 'details',
-    '#title' => t('Translation'),
+    '#title' => t('Translation status'),
     '#open' => $translation_required,
     '#group' => 'advanced',
     'translation_required' => [
       '#type' => 'checkbox',
-      '#title' => t('Translation required'),
+      '#title' => t('Required'),
       '#default_value' => $translation_required,
     ],
   ];

--- a/drupal/web/modules/custom/fsa_translate/fsa_translate.module
+++ b/drupal/web/modules/custom/fsa_translate/fsa_translate.module
@@ -105,11 +105,12 @@ function fsa_translate_mail($key, &$message, $params) {
 
       // Print subject.
       $config = \Drupal::config('config.fsa_translate');
-      $message['subject'] = $config->get('translation_required_mail_subject');
-
-      // Print body with replaced tokens.
-      $text = $config->get('translation_required_mail_body');
       $data = ['node' => $params];
+      $text = $config->get('translation_required_mail_subject');
+      $message['subject'] = \Drupal::token()->replace($text, $data);
+
+      // Print body.
+      $text = $config->get('translation_required_mail_body');
       $message['body'][] = \Drupal::token()->replace($text, $data);
       break;
   }

--- a/drupal/web/modules/custom/fsa_translate/fsa_translate.module
+++ b/drupal/web/modules/custom/fsa_translate/fsa_translate.module
@@ -35,6 +35,15 @@ function fsa_translate_form_node_form_alter(&$form, FormStateInterface $form_sta
       '#title' => t('Required'),
       '#default_value' => $translation_required,
     ],
+    'notify' => [
+      '#type' => 'checkbox',
+      '#title' => t('Notify translation team'),
+      '#states' => array(
+        'visible' => array(
+          ':input[name="translation_required"]' => array('checked' => TRUE),
+        ),
+      ),
+    ],
   ];
 
   // Add submit handler.
@@ -50,8 +59,8 @@ function fsa_translate_form_node_form_alter(&$form, FormStateInterface $form_sta
  */
 function fsa_translate_submit(array $form, FormStateInterface $form_state) {
 
-  // Get node identifier.
-  $nid = $form_state->getFormObject()->getEntity()->id();
+  // Get node.
+  $node = $form_state->getFormObject()->getEntity();
 
   // Get translation required status.
   $translation_required = $form_state->getValue('translation_required');
@@ -59,9 +68,53 @@ function fsa_translate_submit(array $form, FormStateInterface $form_state) {
   // Merge value into tracking table.
   $connection = \Drupal::database();
   $connection->merge('fsa_translation_required')
-    ->key(['nid' => $nid])
+    ->key(['nid' => $node->id()])
     ->fields(['translation_required' => $translation_required])
     ->execute();
+
+  // Notify translation team.
+  if ($form_state->getValue('translation_required') && $form_state->getValue('notify')) {
+    $mailManager = \Drupal::service('plugin.manager.mail');
+    $module = 'fsa_translate';
+    $key = 'translation_required';
+    $config = \Drupal::config('config.fsa_translate');
+    $to = $config->get('translation_required_mail_recipient');
+    $params = $node;
+    $langcode = \Drupal::currentUser()->getPreferredLangcode();
+    $send = TRUE;
+    $result = $mailManager->mail($module, $key, $to, $langcode, $params, NULL, $send);
+    if ($result['result'] !== TRUE) {
+      drupal_set_message(t('There was a problem notifying the translation team.'), 'error');
+    }
+    else {
+      drupal_set_message(t('The translation team has been notified.'));
+    }
+  }
+
+}
+
+/**
+ * Implements hook_mail().
+ */
+function fsa_translate_mail($key, &$message, $params) {
+  switch ($key) {
+
+    // Mail template.
+    case 'translation_required':
+
+      // Print sender address.
+      $message['from'] = \Drupal::config('system.site')->get('mail');
+
+      // Print subject.
+      $config = \Drupal::config('config.fsa_translate');
+      $message['subject'] = $config->get('translation_required_mail_subject');
+
+      // Print body with replaced tokens.
+      $text = $config->get('translation_required_mail_body');
+      $data = ['node' => $params];
+      $message['body'][] = \Drupal::token()->replace($text, $data);
+      break;
+  }
 }
 
 /**

--- a/drupal/web/modules/custom/fsa_translate/fsa_translate.module
+++ b/drupal/web/modules/custom/fsa_translate/fsa_translate.module
@@ -26,13 +26,11 @@ function fsa_translate_form_node_form_alter(&$form, FormStateInterface $form_sta
 
   // Add entity meta details.
   $form['translation'] = [
-    '#type' => 'details',
-    '#title' => t('Translation status'),
-    '#open' => $translation_required,
-    '#group' => 'advanced',
+    '#type' => 'container',
+    '#group' => 'footer',
     'translation_required' => [
       '#type' => 'checkbox',
-      '#title' => t('Required'),
+      '#title' => t('Translation required'),
       '#default_value' => $translation_required,
     ],
     'notify' => [

--- a/drupal/web/modules/custom/fsa_translate/fsa_translate.module
+++ b/drupal/web/modules/custom/fsa_translate/fsa_translate.module
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Alters default translation settings.
+ * Enables content translation management.
  */
 
 use Drupal\Core\Form\FormStateInterface;

--- a/drupal/web/modules/custom/fsa_translate/fsa_translate.routing.yml
+++ b/drupal/web/modules/custom/fsa_translate/fsa_translate.routing.yml
@@ -1,0 +1,7 @@
+fsa_translate.translation_required_configuration:
+  path: '/admin/config/fsa/translation-required'
+  defaults:
+    _form: '\Drupal\fsa_translate\Form\TranslationRequiredConfiguration'
+    _title: 'Translation required configuration'
+  requirements:
+    _permission: 'administer site configuration'

--- a/drupal/web/modules/custom/fsa_translate/src/Form/TranslationRequiredConfiguration.php
+++ b/drupal/web/modules/custom/fsa_translate/src/Form/TranslationRequiredConfiguration.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Drupal\fsa_translate\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Class TranslationRequiredConfiguration.
+ */
+class TranslationRequiredConfiguration extends ConfigFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'fsa_translate_settings';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return ['config.fsa_translate'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config('config.fsa_translate');
+
+    // Settings container.
+    $form['mail'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Mail settings'),
+      '#open' => TRUE,
+    ];
+
+    // Mail recipient.
+    $form['mail']['recipient'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Recipient'),
+      '#default_value' => $config->get('translation_required_mail_recipient'),
+    ];
+
+    // Mail subject.
+    $form['mail']['subject'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Subject'),
+      '#default_value' => $config->get('translation_required_mail_subject'),
+    ];
+
+    // Mail body.
+    $form['mail']['body'] = [
+      '#type' => 'text_format',
+      '#title' => $this->t('Body'),
+      '#format' => 'basic_html',
+      '#default_value' => $config->get('translation_required_mail_body'),
+    ];
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+
+    // Set submitted configuration settings.
+    $this->configFactory->getEditable('config.fsa_translate')
+      ->set('translation_required_mail_recipient', $form_state->getValue('recipient'))
+      ->set('translation_required_mail_subject', $form_state->getValue('subject'))
+      ->set('translation_required_mail_body', $form_state->getValue('body')['value'])
+      ->save();
+    parent::submitForm($form, $form_state);
+  }
+
+}


### PR DESCRIPTION
This is merged to the develop branch and can be tested at: https://fsa.dev.wunder.io/. You will need to pull to a local branch, though, to reconfigure the recipient email address - or else you won't be able to test the notification email.

**Potential issues with this branch:**
1. It's not possible to alter the configuration at: https://fsa.dev.wunder.io/admin/config/fsa/translation-required. The client does not have access to the email account at: welsh.language.translation.unit@food.gov.uk. Does this need to be separated out from the non-alterable configuration?
2. The _latest revision_ and _revision log message_: in the email may sometimes be inaccessible/empty. The client is aware of this, but I'm not sure if this is a good user experience.
