### PR TITLE
Feature/fsa 1094 topic listings and cloud

### DIFF
--- a/drupal/sync/language/cy/field.field.paragraph.topic_cloud.field_topic_cloud.yml
+++ b/drupal/sync/language/cy/field.field.paragraph.topic_cloud.field_topic_cloud.yml
@@ -1,0 +1,1 @@
+label: 'Gwybodaeth yn ôl pwnc'

--- a/drupal/sync/language/cy/views.view.a_to_z.yml
+++ b/drupal/sync/language/cy/views.view.a_to_z.yml
@@ -1,0 +1,4 @@
+display:
+  default:
+    display_options:
+      title: 'Pynciau A-Y'

--- a/drupal/sync/views.view.a_to_z.yml
+++ b/drupal/sync/views.view.a_to_z.yml
@@ -210,6 +210,46 @@ display:
           entity_type: taxonomy_term
           entity_field: vid
           plugin_id: bundle
+        langcode:
+          id: langcode
+          table: taxonomy_term_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value:
+            '***LANGUAGE_language_content***': '***LANGUAGE_language_content***'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: taxonomy_term
+          entity_field: langcode
+          plugin_id: language
       sorts:
         name:
           id: name

--- a/drupal/sync/views.view.taxonomy_term.yml
+++ b/drupal/sync/views.view.taxonomy_term.yml
@@ -31,10 +31,10 @@ display:
       query:
         type: views_query
         options:
-          query_comment: ''
           disable_sql_rewrite: false
-          distinct: false
+          distinct: true
           replica: false
+          query_comment: ''
           query_tags: {  }
       access:
         type: perm

--- a/drupal/web/modules/custom/fsa_topic_listing/src/Plugin/views/area/Letters.php
+++ b/drupal/web/modules/custom/fsa_topic_listing/src/Plugin/views/area/Letters.php
@@ -33,9 +33,8 @@ class Letters extends AreaPluginBase {
       $name_first_chars = [];
       foreach ($terms as $term) {
         if ($term->hasTranslation($language)) {
-          $tid = $term->id();
           $translated_term = \Drupal::service('entity.repository')->getTranslationFromContext($term, $language);
-          $name_first_chars[$tid] = strtoupper(substr($translated_term->getName(), 0, 1));
+          $name_first_chars[$term->id()] = strtoupper(substr($translated_term->getName(), 0, 1));
         }
       }
 

--- a/drupal/web/modules/custom/fsa_topic_listing/src/Plugin/views/area/Letters.php
+++ b/drupal/web/modules/custom/fsa_topic_listing/src/Plugin/views/area/Letters.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\fsa_custom\Plugin\views\area;
+namespace Drupal\fsa_topic_listing\Plugin\views\area;
 
 use Drupal\Core\Link;
 use Drupal\taxonomy\Entity\Term;


### PR DESCRIPTION
This PR

* Changes `/topics` and `/cy/topics` to display only terms in current language
* Changes the topic cloud paragraph to display as translated on welsh version
* Refactors `/topics` page letter navigation code to support translations and moves the code in more meaningful module.
* Adds missing translations

FSA content team is instructed to add the missing translations to Topic and Content type taxonomies to make this fully functional.