### PR TITLE
Fix calls to camelcased variables

### DIFF
--- a/drupal/web/modules/custom/fsa_notify/src/FsaNotifyAPIemail.php
+++ b/drupal/web/modules/custom/fsa_notify/src/FsaNotifyAPIemail.php
@@ -36,7 +36,7 @@ class FsaNotifyAPIemail extends FsaNotifyAPI {
     if (\Drupal::state()->get('fsa_notify.collect_send_log_only')) {
       \Drupal::logger('fsa_notify')->debug('Notify email: <ul><li>To: %email</li><li>template_id %template_id</li><li>personalization: <pre>%personalization</pre></li><li>reference: %reference</li></ul>', [
         '%email' => $email,
-        '%template_id' => $this->template_id,
+        '%template_id' => $this->templateId,
         '%personalization' => print_r($personalisation, 1),
         '%reference' => $reference,
       ]);
@@ -48,7 +48,7 @@ class FsaNotifyAPIemail extends FsaNotifyAPI {
     try {
       $this->api->sendEmail(
         $email,
-        $this->template_id,
+        $this->templateId,
         $personalisation,
         $reference
       );

--- a/drupal/web/modules/custom/fsa_notify/src/FsaNotifyAPIsms.php
+++ b/drupal/web/modules/custom/fsa_notify/src/FsaNotifyAPIsms.php
@@ -45,7 +45,7 @@ class FsaNotifyAPIsms extends FsaNotifyAPI {
     if (\Drupal::state()->get('fsa_notify.collect_send_log_only')) {
       \Drupal::logger('fsa_notify')->debug('Notify SMS: <ul><li>To: %phoneNumber</li><li>template_id %template_id</li><li>personalization: <pre>%personalization</pre></li><li>reference: %reference</li></ul>', [
         '%phoneNumber' => $phoneNumber,
-        '%template_id' => $this->template_id,
+        '%template_id' => $this->templateId,
         '%personalization' => print_r($personalisation, 1),
         '%reference' => $reference,
       ]);
@@ -57,7 +57,7 @@ class FsaNotifyAPIsms extends FsaNotifyAPI {
     try {
       $this->api->sendSms(
         $phoneNumber,
-        $this->template_id,
+        $this->templateId,
         $personalisation,
         $reference
       );

--- a/drupal/web/modules/custom/fsa_notify/src/FsaNotifyMessageDaily.php
+++ b/drupal/web/modules/custom/fsa_notify/src/FsaNotifyMessageDaily.php
@@ -30,8 +30,8 @@ class FsaNotifyMessageDaily extends FsaNotifyMessage {
         'subject' => $this->subject->render(),
         'date' => $this->date,
         'alert_items' => preg_replace('/^/m', self::NOTIFY_TEMPLATE_MESSAGE_STYLE_PREFIX, $items),
-        'login' => $this->login_url,
-        'unsubscribe' => $this->unsubscribe_url,
+        'login' => $this->loginUrl,
+        'unsubscribe' => $this->unsubscribeUrl,
       ],
     ];
 

--- a/drupal/web/modules/custom/fsa_notify/src/FsaNotifyMessageImmediate.php
+++ b/drupal/web/modules/custom/fsa_notify/src/FsaNotifyMessageImmediate.php
@@ -34,8 +34,8 @@ class FsaNotifyMessageImmediate extends FsaNotifyMessage {
         'subject' => $this->subject->render() . ': ' . $title,
         'date' => $this->date,
         'alert_items' => preg_replace('/^/m', self::NOTIFY_TEMPLATE_MESSAGE_STYLE_PREFIX, $item),
-        'login' => $this->login_url,
-        'unsubscribe' => $this->unsubscribe_url,
+        'login' => $this->loginUrl,
+        'unsubscribe' => $this->unsubscribeUrl,
       ];
     }
 

--- a/drupal/web/modules/custom/fsa_notify/src/FsaNotifyMessageWeekly.php
+++ b/drupal/web/modules/custom/fsa_notify/src/FsaNotifyMessageWeekly.php
@@ -30,8 +30,8 @@ class FsaNotifyMessageWeekly extends FsaNotifyMessage {
         'subject' => $this->subject->render(),
         'date' => $this->date,
         'alert_items' => preg_replace('/^/m', self::NOTIFY_TEMPLATE_MESSAGE_STYLE_PREFIX, $items),
-        'login' => $this->login_url,
-        'unsubscribe' => $this->unsubscribe_url,
+        'login' => $this->loginUrl,
+        'unsubscribe' => $this->unsubscribeUrl,
       ],
     ];
 


### PR DESCRIPTION
Changes in this PR clearly got ignored/broken in #813 fixing the coding standard violations on [this part](https://github.com/wunderio/client-UK-FSA-beta/commit/6aa58ac595646b8e77d249708cc8725d6a64be04#diff-1f9fdfd19ecc18ded989a36997f98961L15) of the `FsaNotifyMessage` class. My bad - I should've notice when reviewed but good I spotted while testing before next production deployment.

Without this fix the Notify alerts sending would stop working.