### PR TITLE
Hotfix/fsa 1101 add allergens text aa only

### DIFF
--- a/drupal/web/modules/custom/fsa_alerts_import/src/Plugin/Field/FieldFormatter/AlertPlainTextFormatter.php
+++ b/drupal/web/modules/custom/fsa_alerts_import/src/Plugin/Field/FieldFormatter/AlertPlainTextFormatter.php
@@ -33,6 +33,13 @@ class AlertPlainTextFormatter extends BasicStringFormatter {
   public function viewElements(FieldItemListInterface $items, $langcode) {
     $elements = [];
 
+    if ($items->getEntity()->hasField('field_alert_type')) {
+      $alert_type = $items->getEntity()->field_alert_type->value;
+    }
+    else {
+      $alert_type = FALSE;
+    }
+
     foreach ($items as $delta => $item) {
       $formatted = [];
       $lines = explode(PHP_EOL, $item->value);
@@ -44,7 +51,7 @@ class AlertPlainTextFormatter extends BasicStringFormatter {
           continue;
         }
         // If there is more then 1 line, first line should contain extra data.
-        if (count($lines) > 1 && $i == 0) {
+        if ($alert_type == 'AA' && count($lines) > 1 && $i == 0) {
           $label = $this->t('Allergen(s)');
           $formatted[] = '<p><b>' . $label . ': </b>' . $line . '</p>';
           $i++;


### PR DESCRIPTION
This hotfixes the issue where PRIN alerts may sometimes have the word "Allergen(s)" incorrectly.

Few examples of the issue:
https://www.food.gov.uk/news-alerts/alert/fsa-prin-35-2018
https://www.food.gov.uk/news-alerts/alert/fsa-prin-30-2018