### PR TITLE
Feature/fsa 1149 datalayer uid on subscription

### DIFF
--- a/drupal/web/modules/custom/fsa_signin/fsa_signin.module
+++ b/drupal/web/modules/custom/fsa_signin/fsa_signin.module
@@ -71,11 +71,11 @@ function fsa_signin_form_alter(&$form, FormStateInterface $form_state, $form_id)
     $form['actions']['submit']['#value'] = t('Log in and set password');
 
     // Fetch the reset URL path to get the UID.
-    $current_path = \Drupal::service('path.current')->getPath();
-    $path_args = explode('/', $current_path);
+    $route_path = \Drupal::routeMatch()->getRawParameters('user');
+    $new_uid = $route_path->get('uid');
     // If we have the expected URL, assign the UID to the data layer.
-    if ($path_args[1] == 'user' && $path_args[2] == 'reset' && is_numeric($path_args[3])) {
-      datalayer_add(['userUid' => $path_args[3]]);
+    if (is_numeric($new_uid)) {
+      datalayer_add(['userUid' => $new_uid]);
     }
   }
 }

--- a/drupal/web/modules/custom/fsa_signin/fsa_signin.module
+++ b/drupal/web/modules/custom/fsa_signin/fsa_signin.module
@@ -69,6 +69,16 @@ function fsa_signin_form_alter(&$form, FormStateInterface $form_state, $form_id)
 
     // Change the "Log in" button text.
     $form['actions']['submit']['#value'] = t('Log in and set password');
+
+    // Fetch the reset URL path to get the UID.
+    $current_path = \Drupal::service('path.current')->getPath();
+    $path_args = explode('/', $current_path);
+    // If we have the expected URL, assign the UID to the data layer.
+    if ($path_args[1] == 'user' && $path_args[2] == 'reset' && is_numeric($path_args[3])) {
+      datalayer_add(array(
+        'userUid' => $path_args[3],
+      ));
+    }
   }
 }
 

--- a/drupal/web/modules/custom/fsa_signin/fsa_signin.module
+++ b/drupal/web/modules/custom/fsa_signin/fsa_signin.module
@@ -57,6 +57,23 @@ function fsa_signin_form_alter(&$form, FormStateInterface $form_state, $form_id)
       $arguments = $form['message']['#markup']->getArguments();
       $form['#title'] = t('Thanks for verifying your email %user_name', ['%user_name' => $arguments['%user_name']]);
       $form['message']['#markup'] = t('To complete your alerts subscription you must set a password for your account and select your subscription preferences.');
+
+      // Fetch the reset URL path to get the UID.
+      $route_path = \Drupal::routeMatch()->getRawParameters('user');
+      $new_uid = $route_path->get('uid');
+      // If we have the expected URL, assign the UID to the data layer.
+      if (is_numeric($new_uid)) {
+        datalayer_add([
+          'userUid' => $new_uid,
+          'event' => 'Subscription Set Password',
+          'eventDetails' => [
+            'category' => 'Subscription',
+            'action' => 'Set Password',
+            'label' => 'en',
+            'value' => 0,
+          ],
+        ]);
+      }
     }
 
     if ($form_title == 'Reset password') {
@@ -69,14 +86,6 @@ function fsa_signin_form_alter(&$form, FormStateInterface $form_state, $form_id)
 
     // Change the "Log in" button text.
     $form['actions']['submit']['#value'] = t('Log in and set password');
-
-    // Fetch the reset URL path to get the UID.
-    $route_path = \Drupal::routeMatch()->getRawParameters('user');
-    $new_uid = $route_path->get('uid');
-    // If we have the expected URL, assign the UID to the data layer.
-    if (is_numeric($new_uid)) {
-      datalayer_add(['userUid' => $new_uid]);
-    }
   }
 }
 

--- a/drupal/web/modules/custom/fsa_signin/fsa_signin.module
+++ b/drupal/web/modules/custom/fsa_signin/fsa_signin.module
@@ -75,9 +75,7 @@ function fsa_signin_form_alter(&$form, FormStateInterface $form_state, $form_id)
     $path_args = explode('/', $current_path);
     // If we have the expected URL, assign the UID to the data layer.
     if ($path_args[1] == 'user' && $path_args[2] == 'reset' && is_numeric($path_args[3])) {
-      datalayer_add(array(
-        'userUid' => $path_args[3],
-      ));
+      datalayer_add(['userUid' => $path_args[3]]);
     }
   }
 }

--- a/drupal/web/modules/custom/fsa_signin/fsa_signin.module
+++ b/drupal/web/modules/custom/fsa_signin/fsa_signin.module
@@ -58,27 +58,29 @@ function fsa_signin_form_alter(&$form, FormStateInterface $form_state, $form_id)
       $form['#title'] = t('Thanks for verifying your email %user_name', ['%user_name' => $arguments['%user_name']]);
       $form['message']['#markup'] = t('To complete your alerts subscription you must set a password for your account and select your subscription preferences.');
 
-      // Fetch the reset URL path to get the UID.
-      $route_path = \Drupal::routeMatch()->getRawParameters('user');
-      $new_uid = $route_path->get('uid');
-      // If we have the expected URL, assign the UID to the data layer.
-      if (is_numeric($new_uid)) {
-        datalayer_add([
-          'userUid' => $new_uid,
-          'event' => 'Subscription Set Password',
-          'eventDetails' => [
-            'category' => 'Subscription',
-            'action' => 'Set Password',
-            'label' => 'en',
-            'value' => 0,
-          ],
-        ]);
-      }
+      // Add event information to the data layer.
+      datalayer_add([
+        'event' => 'Subscription Set Password',
+        'eventDetails' => [
+          'category' => 'Subscription',
+          'action' => 'Set Password',
+          'label' => 'en',
+          'value' => 0,
+        ],
+      ]);
     }
 
     if ($form_title == 'Reset password') {
       $form['#title'] = t('Reset your password');
       $form['message']['#markup'] = t('Click the button below to log in to the site and change your password');
+    }
+
+    // Fetch the reset URL path to get the UID.
+    $route_path = \Drupal::routeMatch()->getRawParameters('user');
+    $new_uid = $route_path->get('uid');
+    // If we have the expected URL, assign the UID to the data layer.
+    if (is_numeric($new_uid)) {
+      datalayer_add(['userUid' => $new_uid]);
     }
 
     // Unset the "This login can be used only once." text.

--- a/drupal/web/modules/custom/fsa_signin/src/Controller/DefaultController.php
+++ b/drupal/web/modules/custom/fsa_signin/src/Controller/DefaultController.php
@@ -191,6 +191,19 @@ class DefaultController extends ControllerBase {
     $markup .= '<p>' . $this->t('<p>To complete you subcription please follow the instructions within the email.</p><p>If you do not see the email, please check your spam folder.</p>') . '</p>';
     $markup .= '<p>' . self::betaSigninDescription() . '</p>';
 
+    // Fetch the newly-created UID from the session.
+    // See submitForm() in UserRegistrationForm.php.
+    $session = \Drupal::service('user.private_tempstore')->get('fsa_signin');
+    $reg_uid = $session->get('regUid');
+    if ($reg_uid) {
+      // Add the UID to the data layer, replacing the 0 default.
+      datalayer_add(array(
+        'userUid' => $reg_uid,
+      ));
+      // Delete the session value for when the user navigates away.
+      $session->delete('regUid');
+    }
+
     return [
       '#markup' => $markup,
     ];

--- a/drupal/web/modules/custom/fsa_signin/src/Controller/DefaultController.php
+++ b/drupal/web/modules/custom/fsa_signin/src/Controller/DefaultController.php
@@ -197,9 +197,7 @@ class DefaultController extends ControllerBase {
     $reg_uid = $session->get('regUid');
     if ($reg_uid) {
       // Add the UID to the data layer, replacing the 0 default.
-      datalayer_add(array(
-        'userUid' => $reg_uid,
-      ));
+      datalayer_add(['userUid' => $reg_uid]);
       // Delete the session value for when the user navigates away.
       $session->delete('regUid');
     }

--- a/drupal/web/modules/custom/fsa_signin/src/Form/UserRegistrationForm.php
+++ b/drupal/web/modules/custom/fsa_signin/src/Form/UserRegistrationForm.php
@@ -114,6 +114,12 @@ class UserRegistrationForm extends FormBase {
     try {
       // Save user account.
       $user->save();
+
+      // Save the new UID to the session to use on the data layer.
+      // See thankYouPage() in DefaultController.php.
+      $session = \Drupal::service('user.private_tempstore')->get('fsa_signin');
+      $session->set('regUid', $user->get('uid')->value);
+
       _user_mail_notify('register_no_approval_required', $user);
     }
     catch (\Exception $e) {


### PR DESCRIPTION
Replaces the default userUid value in the dataLayer in 2 instances.
1) After a logged-out user signs up and is shown the 'thank you' page.
2) After clicking the verification email link and being taken to the 'thank you for verifying...' page.
Inspecting the browser console and entering 'dataLayer' will show you the object so you can inspect the values. Previously those pages showed the userUid value as 0.