### PR TITLE
Feature/fsa 1150 notification datalayer updates

### DIFF
--- a/drupal/sync/core.entity_form_display.user.user.default.yml
+++ b/drupal/sync/core.entity_form_display.user.user.default.yml
@@ -6,10 +6,13 @@ dependencies:
     - field.field.user.user.field_delivery_method
     - field.field.user.user.field_delivery_method_news
     - field.field.user.user.field_email_frequency
+    - field.field.user.user.field_initial_delivery_settings
+    - field.field.user.user.field_last_password_reset
     - field.field.user.user.field_notification_cache
     - field.field.user.user.field_notification_cache_sms
     - field.field.user.user.field_notification_method
     - field.field.user.user.field_notification_sms
+    - field.field.user.user.field_password_expiration
     - field.field.user.user.field_subscribed_cons
     - field.field.user.user.field_subscribed_food_alerts
     - field.field.user.user.field_subscribed_news
@@ -46,8 +49,15 @@ content:
     third_party_settings: {  }
     type: options_select
     region: content
-  field_notification_method:
+  field_initial_delivery_settings:
     weight: 9
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
+  field_notification_method:
+    weight: 10
     settings: {  }
     third_party_settings: {  }
     type: options_select
@@ -85,13 +95,15 @@ content:
     type: options_buttons
     region: content
   language:
-    weight: 10
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }
 hidden:
   contact: true
+  field_last_password_reset: true
   field_notification_cache: true
   field_notification_cache_sms: true
+  field_password_expiration: true
   langcode: true
   timezone: true

--- a/drupal/sync/core.entity_view_display.user.user.default.yml
+++ b/drupal/sync/core.entity_view_display.user.user.default.yml
@@ -6,10 +6,13 @@ dependencies:
     - field.field.user.user.field_delivery_method
     - field.field.user.user.field_delivery_method_news
     - field.field.user.user.field_email_frequency
+    - field.field.user.user.field_initial_delivery_settings
+    - field.field.user.user.field_last_password_reset
     - field.field.user.user.field_notification_cache
     - field.field.user.user.field_notification_cache_sms
     - field.field.user.user.field_notification_method
     - field.field.user.user.field_notification_sms
+    - field.field.user.user.field_password_expiration
     - field.field.user.user.field_subscribed_cons
     - field.field.user.user.field_subscribed_food_alerts
     - field.field.user.user.field_subscribed_news
@@ -85,8 +88,11 @@ hidden:
   entity_print_view_epub: true
   entity_print_view_pdf: true
   entity_print_view_word_docx: true
+  field_initial_delivery_settings: true
+  field_last_password_reset: true
   field_notification_cache: true
   field_notification_cache_sms: true
   field_notification_method: true
   field_notification_sms: true
+  field_password_expiration: true
   langcode: true

--- a/drupal/sync/field.field.user.user.field_initial_delivery_settings.yml
+++ b/drupal/sync/field.field.user.user.field_initial_delivery_settings.yml
@@ -1,0 +1,24 @@
+uuid: 4c5ed8c7-ac7c-4ecd-a4ac-d6afb13aa4b6
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.user.field_initial_delivery_settings
+  module:
+    - user
+id: user.user.field_initial_delivery_settings
+field_name: field_initial_delivery_settings
+entity_type: user
+bundle: user
+label: 'Initial delivery settings'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/drupal/sync/field.storage.user.field_initial_delivery_settings.yml
+++ b/drupal/sync/field.storage.user.field_initial_delivery_settings.yml
@@ -1,0 +1,18 @@
+uuid: 549a980a-96bc-4eab-87e4-c58f71f36569
+langcode: en
+status: true
+dependencies:
+  module:
+    - user
+id: user.field_initial_delivery_settings
+field_name: field_initial_delivery_settings
+entity_type: user
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/drupal/web/modules/custom/fsa_signin/fsa_signin.info.yml
+++ b/drupal/web/modules/custom/fsa_signin/fsa_signin.info.yml
@@ -6,4 +6,5 @@ package: FSA
 dependencies:
   - drupal:user
   - drupal:email_registration
+  - drupal:datalayer
   - fsa_custom

--- a/drupal/web/modules/custom/fsa_signin/src/Form/DeliveryOptions.php
+++ b/drupal/web/modules/custom/fsa_signin/src/Form/DeliveryOptions.php
@@ -8,6 +8,7 @@ use Drupal\fsa_custom\FsaCustomHelper;
 use Drupal\fsa_signin\Controller\DefaultController;
 use Drupal\user\Entity\User;
 use Drupal\fsa_signin\SignInService;
+use Drupal\Component\Utility\Html;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -240,7 +241,7 @@ class DeliveryOptions extends FormBase {
     $field_email_frequency = [
       'immediate' => FALSE,
       'daily' => FALSE,
-      'weekly' => FALSE
+      'weekly' => FALSE,
     ];
     if (array_key_exists($email_frequency, $field_email_frequency)) {
       $field_email_frequency[$email_frequency] = TRUE;
@@ -301,6 +302,14 @@ class DeliveryOptions extends FormBase {
 
   /**
    * Creates an array of user info for use in the data layer.
+   *
+   * @param string $form_process
+   *   A data layer action, should be either 'Set' or 'Edit'.
+   * @param array $event_label
+   *   An collection of user profile field information.
+   *
+   * @return array
+   *   Information to be added to the data layer.
    */
   private function deliveryDataLayer($form_process, $event_label) {
     $delivery_edit = [];
@@ -318,15 +327,29 @@ class DeliveryOptions extends FormBase {
 
   /**
    * Converts a string to a machine name style format.
+   *
+   * @param string $string
+   *   A term name.
+   *
+   * @return string
+   *   An updated string formatted for the data layer.
    */
   private function termNameTransform($string) {
     $new_string = strtolower($string);
-    $new_string = preg_replace('/[^a-z0-9_]+/', '_', $new_string);
-    return preg_replace('/_+/', '_', $new_string);
+    $new_string = Html::cleanCssIdentifier($new_string);
+    return preg_replace('/-+/', '_', $new_string);
   }
 
   /**
    * Create an array containing a user's collection of items from a text list.
+   *
+   * @param array $all_items
+   *   All options from the original text list field.
+   * @param array $user_items
+   *   The user's chosen options from the same field.
+   *
+   * @return array
+   *   An updated $all_items with matching user options marked as true.
    */
   private function createTextListArray($all_items, $user_items) {
     foreach ($user_items as $key => $user_item) {
@@ -339,6 +362,14 @@ class DeliveryOptions extends FormBase {
 
   /**
    * Create an array containing a user's collection of terms.
+   *
+   * @param array $all_terms
+   *   All terms from a vocabulary.
+   * @param array $user_terms
+   *   The user's chosen terms from the same vocabulary.
+   *
+   * @return array
+   *   The user's terms formatted for the data layer.
    */
   private function createVocabArray($all_terms, $user_terms) {
     $vocab_array = [];

--- a/drupal/web/modules/custom/fsa_signin/src/Form/DeliveryOptions.php
+++ b/drupal/web/modules/custom/fsa_signin/src/Form/DeliveryOptions.php
@@ -316,10 +316,12 @@ class DeliveryOptions extends FormBase {
     if (in_array($form_process, ['Set', 'Edit'])) {
       $delivery_edit = [
         'event' => 'Subscription Saved',
-        'eventCategory' => 'Subscription',
-        'eventAction' => $form_process,
-        'eventLabel' => $event_label,
-        'eventValue' => 0,
+        'eventDetails' => [
+          'category' => 'Subscription',
+          'action' => $form_process,
+          'label' => $event_label,
+          'value' => 0,
+        ],
       ];
     }
     return $delivery_edit;

--- a/drupal/web/modules/custom/fsa_signin/src/Form/DeliveryOptions.php
+++ b/drupal/web/modules/custom/fsa_signin/src/Form/DeliveryOptions.php
@@ -299,12 +299,12 @@ class DeliveryOptions extends FormBase {
     }
   }
 
-  /*
+  /**
    * Creates an array of user info for use in the data layer.
    */
-  function deliveryDataLayer($form_process, $event_label) {
+  private function deliveryDataLayer($form_process, $event_label) {
     $delivery_edit = [];
-    if (in_array($form_process, array('Set', 'Edit'))) {
+    if (in_array($form_process, ['Set', 'Edit'])) {
       $delivery_edit = [
         'event' => 'Subscription Saved',
         'eventCategory' => 'Subscription',
@@ -316,19 +316,19 @@ class DeliveryOptions extends FormBase {
     return $delivery_edit;
   }
 
-  /*
+  /**
    * Converts a string to a machine name style format.
    */
-  function termNameTransform($string) {
+  private function termNameTransform($string) {
     $new_string = strtolower($string);
     $new_string = preg_replace('/[^a-z0-9_]+/', '_', $new_string);
     return preg_replace('/_+/', '_', $new_string);
   }
 
-  /*
+  /**
    * Create an array containing a user's collection of items from a text list.
    */
-  function createTextListArray($all_items, $user_items) {
+  private function createTextListArray($all_items, $user_items) {
     foreach ($user_items as $key => $user_item) {
       if (array_key_exists($user_item, $all_items)) {
         $all_items[$user_item] = TRUE;
@@ -337,14 +337,14 @@ class DeliveryOptions extends FormBase {
     return $all_items;
   }
 
-  /*
+  /**
    * Create an array containing a user's collection of terms.
    */
-  function createVocabArray($all_terms, $user_terms) {
+  private function createVocabArray($all_terms, $user_terms) {
     $vocab_array = [];
     if (is_array($all_terms) && is_array($user_terms)) {
       // Tidy the format of the user terms array.
-      $user_terms_filtered = array();
+      $user_terms_filtered = [];
       foreach ($user_terms as $user_term) {
         $user_terms_filtered[] = $user_term['target_id'];
       }

--- a/drupal/web/modules/custom/fsa_signin/src/Form/DeliveryOptions.php
+++ b/drupal/web/modules/custom/fsa_signin/src/Form/DeliveryOptions.php
@@ -311,7 +311,7 @@ class DeliveryOptions extends FormBase {
    * @return array
    *   Information to be added to the data layer.
    */
-  private function deliveryDataLayer($form_process, $event_label) {
+  private function deliveryDataLayer($form_process, array $event_label) {
     $delivery_edit = [];
     if (in_array($form_process, ['Set', 'Edit'])) {
       $delivery_edit = [
@@ -351,7 +351,7 @@ class DeliveryOptions extends FormBase {
    * @return array
    *   An updated $all_items with matching user options marked as true.
    */
-  private function createTextListArray($all_items, $user_items) {
+  private function createTextListArray(array $all_items, array $user_items) {
     foreach ($user_items as $key => $user_item) {
       if (array_key_exists($user_item, $all_items)) {
         $all_items[$user_item] = TRUE;
@@ -371,7 +371,7 @@ class DeliveryOptions extends FormBase {
    * @return array
    *   The user's terms formatted for the data layer.
    */
-  private function createVocabArray($all_terms, $user_terms) {
+  private function createVocabArray(array $all_terms, array $user_terms) {
     $vocab_array = [];
     if (is_array($all_terms) && is_array($user_terms)) {
       // Tidy the format of the user terms array.

--- a/drupal/web/modules/custom/fsa_signin/src/Form/DeliveryOptions.php
+++ b/drupal/web/modules/custom/fsa_signin/src/Form/DeliveryOptions.php
@@ -225,14 +225,82 @@ class DeliveryOptions extends FormBase {
     $language = $form_state->getValue('language');
     $account->set('preferred_langcode', $language);
 
+    // Gather user data to put into arrays - text lists.
+    // field_delivery_method
+    $field_delivery_method = ['email' => FALSE, 'sms' => FALSE];
+    foreach ($delivery_method as $key => $method) {
+      if (array_key_exists($method, $field_delivery_method)) {
+        $field_delivery_method[$method] = TRUE;
+      }
+    }
+    // field_delivery_method_news
+    $field_delivery_method_news = ['email' => FALSE];
+    foreach ($delivery_method_news as $key => $method_news) {
+      if (array_key_exists($method_news, $field_delivery_method_news)) {
+        $field_delivery_method_news[$method_news] = TRUE;
+      }
+    }
+    // field_subscribed_food_alerts
+    $food_alerts = array_column($account->get('field_subscribed_food_alerts')->getValue(), 'value');
+    $field_subscribed_food_alerts = ['all' => FALSE];
+    foreach ($food_alerts as $key => $food_alert) {
+      if (array_key_exists($food_alert, $field_subscribed_food_alerts)) {
+        $field_subscribed_food_alerts[$food_alert] = TRUE;
+      }
+    }
+    // field_email_frequency
+    $field_email_frequency = ['immediate' => FALSE, 'daily' => FALSE, 'weekly' => FALSE];
+    if (array_key_exists($email_frequency, $field_email_frequency)) {
+      $field_email_frequency[$email_frequency] = TRUE;
+    }
+    // Gather user data to put into arrays - taxonomies.
+    // field_subscribed_news
+    $news_terms =\Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadTree('news_type');
+    $user_sub_news = $account->get('field_subscribed_news')->getValue();
+    $user_sub_news_filtered = array();
+    foreach ($user_sub_news as $news_tid) {
+      $user_sub_news_filtered[] = $news_tid['target_id'];
+    }
+    $field_subscribed_news = $this->createVocabArray($news_terms, $user_sub_news_filtered);
+    // field_subscribed_notifications
+    $allergy_terms =\Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadTree('alerts_allergen');
+    $user_sub_allergy = $account->get('field_subscribed_notifications')->getValue();
+    $user_sub_allergy_filtered = array();
+    foreach ($user_sub_allergy as $allergy_tid) {
+      $user_sub_allergy_filtered[] = $allergy_tid['target_id'];
+    }
+    $field_subscribed_notifications = $this->createVocabArray($allergy_terms, $user_sub_allergy_filtered);
+    // field_subscribed_cons
+    $cons_terms =\Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadTree('consultations_type_alerts');
+    $user_sub_cons = $account->get('field_subscribed_cons')->getValue();
+    $user_sub_cons_filtered = array();
+    foreach ($user_sub_cons as $cons_tid) {
+      $user_sub_cons_filtered[] = $cons_tid['target_id'];
+    }
+    $field_subscribed_cons = $this->createVocabArray($cons_terms, $user_sub_cons_filtered);
+
+    // Fetch the profile field values to include in the data layer.
+    $event_label = array(
+      'field_subscribed_food_alerts' => $field_subscribed_food_alerts,
+      'field_subscribed_notifications' => $field_subscribed_notifications,
+      'field_subscribed_news' => $field_subscribed_news,
+      'field_subscribed_cons' => $field_subscribed_cons,
+      'field_delivery_method' => $field_delivery_method,
+      'field_notification_sms' => $phone, // plain text
+      'field_delivery_method_news' => $field_delivery_method_news,
+      'field_email_frequency' => $field_email_frequency,
+      'preferred_langcode' => $language,
+    );
+
     // Create a variable for the event session.
     $delivery_field = $account->get('field_initial_delivery_settings')->value;
     if ($delivery_field == 1) {
-      $delivery_edit = $this->deliveryDataLayer('Edit');
+      $delivery_edit = $this->deliveryDataLayer('Edit', $event_label);
     }
     else {
-      $delivery_edit = $this->deliveryDataLayer('Set');
+      $delivery_edit = $this->deliveryDataLayer('Set', $event_label);
     }
+
     // Set the user value to TRUE.
     $account->set('field_initial_delivery_settings', 1);
 
@@ -250,18 +318,36 @@ class DeliveryOptions extends FormBase {
     }
   }
 
-  function deliveryDataLayer($form_process) {
+  function deliveryDataLayer($form_process, $event_label) {
     $delivery_edit = array();
     if (in_array($form_process, array('Set', 'Edit'))) {
       $delivery_edit = array(
         'event' => 'Subscription Saved',
         'eventCategory' => 'Subscription',
         'eventAction' => $form_process,
-        //'eventLabel' => array(),
+        'eventLabel' => $event_label,
         'eventValue' => 0,
       );
     }
     return $delivery_edit;
+  }
+
+  function termNameTransform($string) {
+    $new_string = strtolower($string);
+    $new_string = preg_replace('/[^a-z0-9_]+/', '_', $new_string);
+    return preg_replace('/_+/', '_', $new_string);
+  }
+
+  function createVocabArray($all_terms, $user_terms) {
+    $vocab_array = array();
+    foreach ($all_terms as $this_term) {
+      $term_name = $this->termNameTransform($this_term->name);
+      $vocab_array[$term_name] = FALSE;
+      if (in_array($this_term->tid, $user_terms)) {
+        $vocab_array[$term_name] = TRUE;
+      }
+    }
+    return $vocab_array;
   }
 
 }

--- a/drupal/web/modules/custom/fsa_signin/src/Form/DeliveryOptions.php
+++ b/drupal/web/modules/custom/fsa_signin/src/Form/DeliveryOptions.php
@@ -226,38 +226,42 @@ class DeliveryOptions extends FormBase {
     $account->set('preferred_langcode', $language);
 
     // Gather user data to put into arrays - text lists.
-    // field_delivery_method
+    // field_delivery_method.
     $field_delivery_method = ['email' => FALSE, 'sms' => FALSE];
     $field_delivery_method = $this->createTextListArray($field_delivery_method, $delivery_method);
-    // field_delivery_method_news
+    // field_delivery_method_news.
     $field_delivery_method_news = ['email' => FALSE];
     $field_delivery_method_news = $this->createTextListArray($field_delivery_method_news, $delivery_method_news);
-    // field_subscribed_food_alerts
+    // field_subscribed_food_alerts.
     $food_alerts = array_column($account->get('field_subscribed_food_alerts')->getValue(), 'value');
     $field_subscribed_food_alerts = ['all' => FALSE];
     $field_subscribed_food_alerts = $this->createTextListArray($field_subscribed_food_alerts, $food_alerts);
-    // field_email_frequency
-    $field_email_frequency = ['immediate' => FALSE, 'daily' => FALSE, 'weekly' => FALSE];
+    // field_email_frequency.
+    $field_email_frequency = [
+      'immediate' => FALSE,
+      'daily' => FALSE,
+      'weekly' => FALSE
+    ];
     if (array_key_exists($email_frequency, $field_email_frequency)) {
       $field_email_frequency[$email_frequency] = TRUE;
     }
-    
+
     // Gather user data to put into arrays - taxonomies.
-    // field_subscribed_news
-    $news_terms =\Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadTree('news_type');
+    // field_subscribed_news.
+    $news_terms = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadTree('news_type');
     $user_sub_news = $account->get('field_subscribed_news')->getValue();
     $field_subscribed_news = $this->createVocabArray($news_terms, $user_sub_news);
-    // field_subscribed_notifications
-    $allergy_terms =\Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadTree('alerts_allergen');
+    // field_subscribed_notifications.
+    $allergy_terms = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadTree('alerts_allergen');
     $user_sub_allergy = $account->get('field_subscribed_notifications')->getValue();
     $field_subscribed_notifications = $this->createVocabArray($allergy_terms, $user_sub_allergy);
-    // field_subscribed_cons
-    $cons_terms =\Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadTree('consultations_type_alerts');
+    // field_subscribed_cons.
+    $cons_terms = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadTree('consultations_type_alerts');
     $user_sub_cons = $account->get('field_subscribed_cons')->getValue();
     $field_subscribed_cons = $this->createVocabArray($cons_terms, $user_sub_cons);
 
     // Fetch the profile field values to include in the data layer.
-    $event_label = array(
+    $event_label = [
       'field_subscribed_food_alerts' => $field_subscribed_food_alerts,
       'field_subscribed_notifications' => $field_subscribed_notifications,
       'field_subscribed_news' => $field_subscribed_news,
@@ -267,7 +271,7 @@ class DeliveryOptions extends FormBase {
       'field_delivery_method_news' => $field_delivery_method_news,
       'field_email_frequency' => $field_email_frequency,
       'preferred_langcode' => $language,
-    );
+    ];
 
     // Create a variable for the event session.
     $delivery_field = $account->get('field_initial_delivery_settings')->value;
@@ -295,29 +299,35 @@ class DeliveryOptions extends FormBase {
     }
   }
 
-  // Creates an array of user info for use in the data layer.
+  /*
+   * Creates an array of user info for use in the data layer.
+   */
   function deliveryDataLayer($form_process, $event_label) {
-    $delivery_edit = array();
+    $delivery_edit = [];
     if (in_array($form_process, array('Set', 'Edit'))) {
-      $delivery_edit = array(
+      $delivery_edit = [
         'event' => 'Subscription Saved',
         'eventCategory' => 'Subscription',
         'eventAction' => $form_process,
         'eventLabel' => $event_label,
         'eventValue' => 0,
-      );
+      ];
     }
     return $delivery_edit;
   }
 
-  // Converts a string to a machine name style format.
+  /*
+   * Converts a string to a machine name style format.
+   */
   function termNameTransform($string) {
     $new_string = strtolower($string);
     $new_string = preg_replace('/[^a-z0-9_]+/', '_', $new_string);
     return preg_replace('/_+/', '_', $new_string);
   }
 
-  // Create an array containing a user's collection of items from a text list.
+  /*
+   * Create an array containing a user's collection of items from a text list.
+   */
   function createTextListArray($all_items, $user_items) {
     foreach ($user_items as $key => $user_item) {
       if (array_key_exists($user_item, $all_items)) {
@@ -327,9 +337,11 @@ class DeliveryOptions extends FormBase {
     return $all_items;
   }
 
-  // Create an array containing a user's collection of terms.
+  /*
+   * Create an array containing a user's collection of terms.
+   */
   function createVocabArray($all_terms, $user_terms) {
-    $vocab_array = array();
+    $vocab_array = [];
     if (is_array($all_terms) && is_array($user_terms)) {
       // Tidy the format of the user terms array.
       $user_terms_filtered = array();


### PR DESCRIPTION
Covers 2 Jira tasks, 1150 and 1151.
**1150**
When submitting the user preferences form, the dataLayer should show some extra information about the event:
`'event' : 'Subscription Saved'`
`'eventCategory' : 'Subscription'`
`'eventValue' : 0`
If this is the first time the user has submitted this form, it should add:
`'eventAction' : 'Set'`
Every subsequent save should instead show this:
`'eventAction' : 'Set'`
**1151**
After the form submission the dataLayer should also have an `eventLabel` object which contains information from the user's profile fields. The information here should match what you saved when submitting the form.