### PR TITLE
FSA-1152: Set remote address to null when pre-saved

### DIFF
--- a/drupal/web/modules/custom/fsa_webform/fsa_webform.module
+++ b/drupal/web/modules/custom/fsa_webform/fsa_webform.module
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\webform\WebformSubmissionInterface;
 
 /**
  * Implements hook_form_alter().
@@ -68,4 +69,13 @@ function fsa_webform_form_alter(&$form, FormStateInterface $form_state, $form_id
       }
     }
   }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_presave().
+ *
+ * Stops webform from saving the IP address of the submitting user.
+ */
+function fsa_webform_webform_submission_presave(WebformSubmissionInterface $entity) {
+  $entity->remote_addr->value = NULL;
 }


### PR DESCRIPTION
This PR should stop webform from saving the IP address of the submitting user. With regard to clearing:

> all prior IP address submission

values, noted in https://wunder.atlassian.net/browse/FSA-1152, some simple SQL should do it:

`UPDATE webform_submission SET remote_addr = NULL;`

...however, changing the live database will need some careful management, I imagine.