### PR TITLE
Feature/fsa 1111 aria page attribute

### DIFF
--- a/drupal/web/themes/custom/fsa/fsa.theme
+++ b/drupal/web/themes/custom/fsa/fsa.theme
@@ -102,6 +102,8 @@ function fsa_page_attachments_alter(&$variables) {
  */
 function fsa_preprocess_breadcrumb(&$variables) {
   // Treat final breadcrumb entry as the current page, and add aria-current attribute.
-  $last_item_index = count($variables['breadcrumb']) -1;
+  $last_item_index = count($variables['breadcrumb']);
+  // Decrement count value separately to keep PHPCS happy.
+  $last_item_index--;
   $variables['breadcrumb'][$last_item_index]['attributes']['aria-current'] = 'page';
 }

--- a/drupal/web/themes/custom/fsa/fsa.theme
+++ b/drupal/web/themes/custom/fsa/fsa.theme
@@ -96,3 +96,12 @@ function fsa_page_attachments_alter(&$variables) {
   ];
   $variables['#attached']['html_head'][] = [$googlefonts, 'googlefonts'];
 }
+
+/**
+ * Implements hook_preprocess_breadcrumb().
+ */
+function fsa_preprocess_breadcrumb(&$variables) {
+  // Treat final breadcrumb entry as the current page, and add aria-current attribute.
+  $last_item_index = count($variables['breadcrumb']) -1;
+  $variables['breadcrumb'][$last_item_index]['attributes']['aria-current'] = 'page';
+}

--- a/drupal/web/themes/custom/fsa/template/navigation/breadcrumb.html.twig
+++ b/drupal/web/themes/custom/fsa/template/navigation/breadcrumb.html.twig
@@ -12,7 +12,13 @@
   {% for item in breadcrumb %}
     <div class="breadcrumb__item">
       {% if item.url %}
-        <a href="{{ item.url }}" class="breadcrumb__link">{{ item.text }}</a>
+        {% spaceless %}
+        <a href="{{ item.url }}" class="breadcrumb__link"
+          {% if item.attributes %}{% for key,value in item.attributes %}
+            {{ key }}="{{ value }}"
+          {% endfor %}{% endif %}
+            >{{ item.text }}</a>
+        {% endspaceless %}
       {% else %}
         {{ item.text }}
       {% endif %}


### PR DESCRIPTION
This PR adds a preprocess hook to the fsa.theme file to add an extra attribute to the final breadcrumb item. It also checks for an attributes array in the Twig template and prints them out at the end of the link element.