### PR TITLE
Analytics datalayer updates to validation link and change password forms

### DIFF
--- a/drupal/web/modules/custom/fsa_signin/fsa_signin.module
+++ b/drupal/web/modules/custom/fsa_signin/fsa_signin.module
@@ -60,10 +60,10 @@ function fsa_signin_form_alter(&$form, FormStateInterface $form_state, $form_id)
 
       // Add event information to the data layer.
       datalayer_add([
-        'event' => 'Subscription Set Password',
+        'event' => 'Subscription Login To Set Password',
         'eventDetails' => [
           'category' => 'Subscription',
-          'action' => 'Set Password',
+          'action' => 'Email Verified',
           'label' => 'en',
           'value' => 0,
         ],

--- a/drupal/web/modules/custom/fsa_signin/src/Form/ChangePassword.php
+++ b/drupal/web/modules/custom/fsa_signin/src/Form/ChangePassword.php
@@ -62,6 +62,17 @@ class ChangePassword extends FormBase {
       '#value' => $this->t('Change password'),
     ];
 
+    // Add event information to the data layer.
+    datalayer_add([
+      'event' => 'Subscription Set Password',
+      'eventDetails' => [
+        'category' => 'Subscription',
+        'action' => 'Set Password',
+        'label' => 'Set',
+        'value' => 0,
+      ],
+    ]);
+
     return $form;
   }
 


### PR DESCRIPTION
Add extra info to the data layer (enter 'dataLayer' in the browser console to test). Additional 'event' and 'eventDetail' has been added on the 'Thanks for verifying...' page after clicking the validation email link, and on the new password creation form page you see after that. See screenshot for an example of what to see on the password page.

<img width="294" alt="screen shot 2018-07-20 at 10 38 55" src="https://user-images.githubusercontent.com/39907914/43064394-b260d5d4-8e56-11e8-9280-8787af311c4b.png">
