### PR TITLE
Feature/fsa 1153 alerts prefs selection fix

### DIFF
--- a/drupal/web/modules/custom/fsa_signin/js/fsa_signin.subscription_alerts.js
+++ b/drupal/web/modules/custom/fsa_signin/js/fsa_signin.subscription_alerts.js
@@ -10,7 +10,7 @@
     // Drupal's core JS will execute behaviors' attach functions when the DOM is ready.
     attach: function (context, settings) {
 
-      // Form id's to the array to implement "select all" option for checkbox lists.
+      // Form ids to the array to implement "select all" option for checkbox lists.
       // Script expects FAPI to have the "all" option key named "all".
       var forms = [
         "edit-subscribed-news",

--- a/drupal/web/modules/custom/fsa_signin/src/Form/AlertsForRegistrationForm.php
+++ b/drupal/web/modules/custom/fsa_signin/src/Form/AlertsForRegistrationForm.php
@@ -120,7 +120,7 @@ class AlertsForRegistrationForm extends FormBase {
       $selected_tids = array_keys($form['alert_tids_for_registration']['#options']);
 
       // 'All' will be index 0.
-      unset($selected_tids [0]);
+      unset($selected_tids[0]);
     }
 
     $user->set('field_subscribed_food_alerts', $food_alert_registration);

--- a/drupal/web/modules/custom/fsa_signin/src/Form/AlertsForRegistrationForm.php
+++ b/drupal/web/modules/custom/fsa_signin/src/Form/AlertsForRegistrationForm.php
@@ -103,9 +103,25 @@ class AlertsForRegistrationForm extends FormBase {
     $food_alert_registration = array_filter(array_values($food_alert_registration));
 
     $alert_tids = $form_state->getValue('alert_tids_for_registration');
+    // If 'all' is the only selection item, the user may have left this item
+    // checked but not have anything else selected. In that case, we should
+    // interpret this selection as a desire to receive from all categories
+    // so we need to fill the $alert_tids with all term ids from that vocabulary.
+    $has_selected_all = !empty($alert_tids['all']);
+
     unset($alert_tids['all']);
     // Filter only those user has selected:
     $selected_tids = array_filter(array_values($alert_tids));
+
+    if ($has_selected_all) {
+      // Fill the $selected_tids array with values (use from the original
+      // form element values to avoid reloading taxonomy data) because the
+      // user has indicated they want to receive 'All' things.
+      $selected_tids = array_keys($form['alert_tids_for_registration']['#options']);
+
+      // 'All' will be index 0.
+      unset($selected_tids [0]);
+    }
 
     $user->set('field_subscribed_food_alerts', $food_alert_registration);
     $user->set('field_subscribed_notifications', $selected_tids);


### PR DESCRIPTION
PR ensures that if the user manages to:

- Select all checkboxes using 'All'
- Unticks all options except 'All'
- Saves

Then server side code will repopulate the selection values to ensure they get all values rather than none at all.