### PR TITLE
Reduce number of rendered items on taxonomy listing pages

### DIFF
--- a/drupal/sync/views.view.taxonomy_term.yml
+++ b/drupal/sync/views.view.taxonomy_term.yml
@@ -56,7 +56,7 @@ display:
       pager:
         type: full
         options:
-          items_per_page: 250
+          items_per_page: 25
           offset: 0
           id: 0
           total_pages: 0


### PR DESCRIPTION
This PR is due to observations from New Relic listing pages such as topics/fsa-activities as having a relatively time consuming page load time. On closer inspection, we render 250 items per page.

We already have suitable cache control via the tag based system, so dropping the rendered item count to 25 from 250 shows the following improvements:

250 items per page: 10.948 seconds, 0.058 with cache hit.
25 items per page: 4.318 seconds, 0.044 with cache hit.