### PR TITLE
Make isset() check for id value instead of email when assigning value to parameter

### DIFF
--- a/drupal/web/modules/custom/fsa_signin/src/Form/UnsubscribeForm.php
+++ b/drupal/web/modules/custom/fsa_signin/src/Form/UnsubscribeForm.php
@@ -53,7 +53,7 @@ class UnsubscribeForm extends FormBase {
     // Format of link to unsubscribe: ?email=foo@bar.com&id=123
     // where uid must match with respective email in db.
     $email = (isset($query['email'])) ? $query['email'] : FALSE;
-    $uid = (isset($query['email'])) ? $query['id'] : FALSE;
+    $uid = (isset($query['id'])) ? $query['id'] : FALSE;
 
     $user = user_load_by_mail($email);
 


### PR DESCRIPTION
This PR fixes a tiny, but non-serious bug in the subscribe handling code. It currently checks whether the email parameter is set in order to assign the id parameter value, but it should be checking to see if the id value is present in the URL and not the email.

Not critical as both are generally present and it wouldn't make sense to include just one, but thought it was worth correcting as it was in front of me for something else.