### PR TITLE
FSA-1095: Add account cancellation event and wire up to form submit handler

### DIFF
--- a/drupal/web/modules/custom/fsa_alerts_monitor/fsa_alerts_monitor.services.yml
+++ b/drupal/web/modules/custom/fsa_alerts_monitor/fsa_alerts_monitor.services.yml
@@ -14,6 +14,11 @@ services:
         tags:
           - { name: event_subscriber }
 
+  fsa_alerts_monitor.user.cancel:
+        class: Drupal\fsa_alerts_monitor\EventSubscriber\UserCancelSubscriber
+        tags:
+          - { name: event_subscriber }
+
   fsa_alerts_monitor.service:
       class: Drupal\fsa_alerts_monitor\FsaAlertsMonitorService
       arguments: []

--- a/drupal/web/modules/custom/fsa_alerts_monitor/src/EventSubscriber/UserCancelSubscriber.php
+++ b/drupal/web/modules/custom/fsa_alerts_monitor/src/EventSubscriber/UserCancelSubscriber.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Drupal\fsa_alerts_monitor\EventSubscriber;
+
+use Drupal\fsa_signin\Event\UserCancelEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class UserCancelSubscriber implements EventSubscriberInterface {
+
+  /**
+   * Callback for this event to register when a user cancels their
+   * account via the profile page(s).
+   *
+   * @param \Drupal\fsa_signin\Event\UserCancelEvent $event
+   *   Event object containing our data.
+   * @throws \Exception
+   */
+  public function logCancellation(UserCancelEvent $event) {
+    // Unwrap the user object from the event.
+    $user = $event->getUser();
+
+    $alert_monitor = \Drupal::service('fsa_alerts_monitor.service');
+    $alert_monitor->trackEvent($user, 'Cancel account', \Drupal::time()->getCurrentTime());
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events['fsa_alerts_monitor.user.cancel'][] = ['logCancellation'];
+    return $events;
+  }
+
+}

--- a/drupal/web/modules/custom/fsa_signin/src/Event/UserCancelEvent.php
+++ b/drupal/web/modules/custom/fsa_signin/src/Event/UserCancelEvent.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Drupal\fsa_signin\Event;
+
+use Drupal\user\UserInterface;
+use Symfony\Component\EventDispatcher\Event;
+
+class UserCancelEvent extends Event {
+
+  /**
+   * User entity.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $user;
+
+  /**
+   * Constructs an user event object.
+   *
+   * @param \Drupal\user\UserInterface $user
+   *   Object that implements this interface.
+   */
+  public function __construct(UserInterface $user) {
+    $this->user = $user;
+  }
+
+  /**
+   * Get the inserted user.
+   *
+   * @return \Drupal\user\UserInterface
+   *   Returns user object.
+   */
+  public function getUser() {
+    return $this->user;
+  }
+
+}

--- a/drupal/web/modules/custom/fsa_signin/src/Form/DeleteAccountConfirmation.php
+++ b/drupal/web/modules/custom/fsa_signin/src/Form/DeleteAccountConfirmation.php
@@ -7,6 +7,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 use Drupal\fsa_signin\Controller\DefaultController;
 use Drupal\user\Entity\User;
+use Drupal\fsa_signin\Event\UserCancelEvent;
 
 /**
  * Defines a confirmation form for deleting mymodule data.
@@ -125,6 +126,13 @@ class DeleteAccountConfirmation extends ConfirmFormBase {
     $account = $form_state->getValue('account');
     $uid = $account->id();
     $email = $account->getEmail();
+
+    // Emit a new event to capture this activity. Could tie in with
+    // hook_user_cancel() but we're only interested in activity on this very
+    // specific form/interaction point and an event fits with
+    // the wider approach in fsa_alerts_monitor.
+    $user = User::load($uid);
+    \Drupal::service('event_dispatcher')->dispatch('fsa_alerts_monitor.user.cancel', new UserCancelEvent($user));
 
     // "Anonymise the email.
     $email = '***' . strstr($email, '@');


### PR DESCRIPTION
PR introduces a new event to emit from when users cancel their account from pages linked off from /profile, rather than the general user cancel event. We don't want to track any instances of users being removed in general, eg: from the admin forms.