### PR TITLE
FSA-1073: Set specific webform purge thresholds into config and add whitelist

### DIFF
--- a/drupal/sync/config_ignore.settings.yml
+++ b/drupal/sync/config_ignore.settings.yml
@@ -11,5 +11,9 @@ ignored_config_entities:
   18: 'embed.button.image:dependencies.content'
   20: 'embed.button.node:icon_uuid'
   22: 'embed.button.node:dependencies.content'
+  24: webform.webform.food_fraud_crime
+  26: webform.webform.food_poisoning
+  28: webform.webform.foreign_object
+  30: webform.webform.poor_hygiene_practices
 _core:
   default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk

--- a/drupal/sync/webform.webform.food_fraud_crime.yml
+++ b/drupal/sync/webform.webform.food_fraud_crime.yml
@@ -47,13 +47,7 @@ settings:
   submission_log: false
   submission_user_columns:
     - element__details_of_problem
-    - element__people_businesses_involved
     - element__where_lookup
-    - element__when_and_how_often
-    - element__why_involved_and_how
-    - element__explain_how_you_know
-    - element__how_many_aware
-    - element__reported_to_anyone_else
     - element__name
     - element__email
   submission_login: false
@@ -103,8 +97,8 @@ settings:
   entity_limit_total_interval: null
   entity_limit_user: null
   entity_limit_user_interval: null
-  purge: none
-  purge_days: null
+  purge: all
+  purge_days: 1
   results_disabled: false
   results_disabled_ignore: false
   token_update: false

--- a/drupal/sync/webform.webform.food_fraud_crime.yml
+++ b/drupal/sync/webform.webform.food_fraud_crime.yml
@@ -47,7 +47,13 @@ settings:
   submission_log: false
   submission_user_columns:
     - element__details_of_problem
+    - element__people_businesses_involved
     - element__where_lookup
+    - element__when_and_how_often
+    - element__why_involved_and_how
+    - element__explain_how_you_know
+    - element__how_many_aware
+    - element__reported_to_anyone_else
     - element__name
     - element__email
   submission_login: false

--- a/drupal/sync/webform.webform.food_poisoning.yml
+++ b/drupal/sync/webform.webform.food_poisoning.yml
@@ -51,7 +51,6 @@ settings:
     - element__fsa_establishment_postal_code
     - element__fsa_establishment_la_name
     - element__fsa_establishment_la_email
-    - element__people_affected
     - element__symptoms_details
     - element__when_did_you_illness_start_and_end_
     - element__has_visited_gp
@@ -110,8 +109,8 @@ settings:
   entity_limit_total_interval: null
   entity_limit_user: null
   entity_limit_user_interval: null
-  purge: none
-  purge_days: null
+  purge: all
+  purge_days: 6
   results_disabled: false
   results_disabled_ignore: false
   token_update: false

--- a/drupal/sync/webform.webform.food_poisoning.yml
+++ b/drupal/sync/webform.webform.food_poisoning.yml
@@ -51,6 +51,7 @@ settings:
     - element__fsa_establishment_postal_code
     - element__fsa_establishment_la_name
     - element__fsa_establishment_la_email
+    - element__people_affected
     - element__symptoms_details
     - element__when_did_you_illness_start_and_end_
     - element__has_visited_gp

--- a/drupal/sync/webform.webform.foreign_object.yml
+++ b/drupal/sync/webform.webform.foreign_object.yml
@@ -55,7 +55,6 @@ settings:
     - element__fsa_establishment_postal_code
     - element__fsa_establishment_la_email
     - element__when_purchased
-    - element__where_item_stored
     - element__premises_contacted_action_taken
     - element__name
     - element__email
@@ -112,8 +111,8 @@ settings:
   entity_limit_total_interval: null
   entity_limit_user: null
   entity_limit_user_interval: null
-  purge: none
-  purge_days: null
+  purge: all
+  purge_days: 6
   results_disabled: false
   results_disabled_ignore: false
   token_update: false

--- a/drupal/sync/webform.webform.foreign_object.yml
+++ b/drupal/sync/webform.webform.foreign_object.yml
@@ -55,6 +55,7 @@ settings:
     - element__fsa_establishment_postal_code
     - element__fsa_establishment_la_email
     - element__when_purchased
+    - element__where_item_stored
     - element__premises_contacted_action_taken
     - element__name
     - element__email

--- a/drupal/sync/webform.webform.poor_hygiene_practices.yml
+++ b/drupal/sync/webform.webform.poor_hygiene_practices.yml
@@ -107,8 +107,8 @@ settings:
   entity_limit_total_interval: null
   entity_limit_user: null
   entity_limit_user_interval: null
-  purge: none
-  purge_days: null
+  purge: all
+  purge_days: 6
   results_disabled: false
   results_disabled_ignore: false
   token_update: false

--- a/drupal/web/sites/default/settings.php
+++ b/drupal/web/sites/default/settings.php
@@ -70,6 +70,10 @@ $settings['config_readonly_whitelist_patterns'] = [
   'config.fsa_consultations',
   'force_password_change.settings',
   'fsa_content_reminder.settings',
+  'webform.webform.food_fraud_crime',
+  'webform.webform.food_poisoning',
+  'webform.webform.foreign_object',
+  'webform.webform.poor_hygiene_practices',
 ];
 
 // Allow configuration changes via drush (command line).


### PR DESCRIPTION
PR aims to provide FSA with a means to control settings on a few, named webforms. Config updated after setting submission purge threshold to the values requested by FSA.

Changes to submission_user_columns not totally expected, but seems to represent the current definition of those forms as they're kept in the database on live so not terribly concerned at this point.