### PR TITLE
Feature/fsa 1095 google measurement protocol

### DIFF
--- a/drupal/sync/core.extension.yml
+++ b/drupal/sync/core.extension.yml
@@ -66,6 +66,7 @@ module:
   fsa_document_library: 0
   fsa_es: 0
   fsa_establishment_lookup: 0
+  fsa_gds_mp: 0
   fsa_gtm: 0
   fsa_lander: 0
   fsa_notify: 0

--- a/drupal/web/modules/custom/fsa_gds_mp/fsa_gds_mp.info.yml
+++ b/drupal/web/modules/custom/fsa_gds_mp/fsa_gds_mp.info.yml
@@ -1,0 +1,7 @@
+name: FSA Google Data Studio Measurement Protocol 
+type: module
+description: "Sends daily alerts activity summary data to Google Data Studio using Measurement Protocol"
+core: 8.x
+package: FSA
+dependencies:
+  - fsa_alerts_monitor

--- a/drupal/web/modules/custom/fsa_gds_mp/fsa_gds_mp.module
+++ b/drupal/web/modules/custom/fsa_gds_mp/fsa_gds_mp.module
@@ -78,7 +78,7 @@ EOT;
 
   $query = $connection->query($sql);
 
-  return (int) $query->fetchAll();
+  return (int) array_pop($query->fetchAssoc());
 }
 
 /**
@@ -129,7 +129,7 @@ EOT;
 
   $query = $connection->query($sql);
 
-  return (int) $query->fetchAll();
+  return (int) array_pop($query->fetchAssoc());
 }
 
 /**
@@ -155,7 +155,7 @@ EOT;
 
   $query = $connection->query($sql);
 
-  return (int) $query->fetchAll();
+  return (int) array_pop($query->fetchAssoc());
 }
 
 /**
@@ -181,7 +181,7 @@ EOT;
 
   $query = $connection->query($sql);
 
-  return (int) $query->fetchAll();
+  return (int) array_pop($query->fetchAssoc());
 }
 
 /**

--- a/drupal/web/modules/custom/fsa_gds_mp/fsa_gds_mp.module
+++ b/drupal/web/modules/custom/fsa_gds_mp/fsa_gds_mp.module
@@ -6,6 +6,8 @@
 
 use Drupal\taxonomy\Entity\Term;
 
+const FSA_GDS_MP_UUID = '4072b6b3-1f23-481b-8269-69d801a74224';
+
 /**
  * Implements hook_cron().
  */
@@ -245,7 +247,7 @@ function fsa_gsp_mp_send(array $payload) {
       'v' => 1,
       't' => 'event',
       'tid' => \Drupal::config('fsa_gds_mp')->get('ga_tracking_id'),
-      'cid' => \Drupal::service('uuid')->generate(),
+      'cid' => FSA_GDS_MP_UUID,
       'cd1' => urldecode('FSA%20-%20MP%20-%20Statistics%20Reporting%20-%20food.gov.uk'),
       'ds' => 'drupal',
       'dh' => \Drupal::request()->getHost(),

--- a/drupal/web/modules/custom/fsa_gds_mp/fsa_gds_mp.module
+++ b/drupal/web/modules/custom/fsa_gds_mp/fsa_gds_mp.module
@@ -205,7 +205,7 @@ function fsa_gds_mp_count_by_alert_categories() {
     $term_entity = Term::load($term->tid);
     $category_counts[$term_entity->field_alert_notation->value] = fsa_gds_mp_count_by_category($term->tid);
   }
-  
+
   return $category_counts;
 }
 

--- a/drupal/web/modules/custom/fsa_gds_mp/fsa_gds_mp.module
+++ b/drupal/web/modules/custom/fsa_gds_mp/fsa_gds_mp.module
@@ -252,7 +252,7 @@ function fsa_gsp_mp_send(array $payload) {
       'ds' => 'drupal',
       'dh' => \Drupal::request()->getHost(),
       'dt' => urlencode('Statistics reporting'),
-      'ec' => 'Alerts%20Usage',
+      'ec' => 'Alerts Usage',
       'ev' => 0,
     ],
   ];

--- a/drupal/web/modules/custom/fsa_gds_mp/fsa_gds_mp.module
+++ b/drupal/web/modules/custom/fsa_gds_mp/fsa_gds_mp.module
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * @file
+ */
+
+use GuzzleHttp\Client as HttpClient;
+
+/**
+ * Implements hook_cron().
+ */
+function fsa_gds_mp_cron() {
+  $request_time = \Drupal::time()->getRequestTime();
+
+  // Get state setting to fetch last run time.
+  $last_run = 0;
+  // $last_run = \Drupal::state()->get('fsa_gsa_mp.last_run', 0);.
+
+  // If time to run is < 24hrs, exit early.
+  if ($request_time <= strtotime('+1 day', $last_run)) {
+    var_dump($request_time <= strtotime('+1 day', $last_run));
+    return;
+  }
+
+  // Otherwise, gather daily metrics...
+  $payload = fsa_gds_mp_gather_daily_metrics();
+
+  // And transmit to GDS endpoint.
+  fsa_gsp_mp_send($payload);
+
+  // Then set the next run timestamp to +24hrs.
+  \Drupal::state()->set('fsa_gsa_mp.last_run', $request_time);
+}
+
+/**
+ * Callback to gather the alerts metrics we want to share with GDS.
+ *
+ * @return array
+ *   Key/value array of daily metrics to submit.
+ */
+function fsa_gds_mp_gather_daily_metrics() {
+  return [
+    'subscribe' => 12345,
+    'unsubscribe' => 100,
+  ];
+}
+
+/**
+ * Callback to make HTTP requests to measurement protocol endpoint.
+ *
+ * @param array $payload
+ *   Contains metrics data for us to send to GDS.
+ * @throws \GuzzleHttp\Exception\GuzzleException
+ */
+function fsa_gsp_mp_send(array $payload) {
+  // Debugging with netcat.
+  $uri = 'http://localhost:6666';
+  // $uri = 'https://www.google-analytics.com/collect';
+  // Measurement protocol API docs here: https://developers.google.com/analytics/devguides/collection/protocol/v1/devguide#event.
+  $options = [
+    'headers' => [
+      'Cache' => 'no-cache',
+    ],
+    'query' => [
+      'v' => 1,
+      't' => 'event',
+      'tid' => 'UA-54078849-3',
+      // 'cid' => '',.
+      'ec' => 'Alerts%20Usage',
+      'ea' => 'Subscribed%20Users',
+      'ev' => 12345,
+    ]
+  ];
+
+  $client = new HttpClient();
+  $response = $client->request('POST', $uri, $options);
+}

--- a/drupal/web/modules/custom/fsa_gds_mp/fsa_gds_mp.module
+++ b/drupal/web/modules/custom/fsa_gds_mp/fsa_gds_mp.module
@@ -205,8 +205,7 @@ function fsa_gds_mp_count_by_alert_categories() {
     $term_entity = Term::load($term->tid);
     $category_counts[$term_entity->field_alert_notation->value] = fsa_gds_mp_count_by_category($term->tid);
   }
-
-
+  
   return $category_counts;
 }
 

--- a/drupal/web/modules/custom/fsa_gds_mp/fsa_gds_mp.module
+++ b/drupal/web/modules/custom/fsa_gds_mp/fsa_gds_mp.module
@@ -13,12 +13,10 @@ function fsa_gds_mp_cron() {
   $request_time = \Drupal::time()->getRequestTime();
 
   // Get state setting to fetch last run time.
-  $last_run = 0;
-  // $last_run = \Drupal::state()->get('fsa_gsa_mp.last_run', 0);.
+  $last_run = \Drupal::state()->get('fsa_gsa_mp.last_run', 0);
 
   // If time to run is < 24hrs, exit early.
   if ($request_time <= strtotime('+1 day', $last_run)) {
-    var_dump($request_time <= strtotime('+1 day', $last_run));
     return;
   }
 
@@ -235,7 +233,6 @@ function fsa_gds_mp_count_by_category(int $term_id) {
  *
  * @param array $payload
  *   Contains metrics data for us to send to GDS.
- * @throws \GuzzleHttp\Exception\GuzzleException
  */
 function fsa_gsp_mp_send(array $payload) {
   $uri = 'https://www.google-analytics.com/collect';
@@ -249,6 +246,7 @@ function fsa_gsp_mp_send(array $payload) {
       't' => 'event',
       'tid' => \Drupal::config('fsa_gds_mp')->get('ga_tracking_id'),
       'cid' => \Drupal::service('uuid')->generate(),
+      'cd1' => urldecode('FSA%20-%20MP%20-%20Statistics%20Reporting%20-%20food.gov.uk'),
       'ds' => 'drupal',
       'dh' => \Drupal::request()->getHost(),
       'dt' => urlencode('Statistics reporting'),
@@ -258,8 +256,6 @@ function fsa_gsp_mp_send(array $payload) {
   ];
 
   foreach ($payload as $event_id => $event_value) {
-    $event_id = urlencode($event_id);
-
     if (is_array($event_value)) {
       $event_value = json_encode($event_value);
     }

--- a/drupal/web/modules/custom/fsa_gds_mp/fsa_gds_mp.module
+++ b/drupal/web/modules/custom/fsa_gds_mp/fsa_gds_mp.module
@@ -5,6 +5,7 @@
  */
 
 use GuzzleHttp\Client as HttpClient;
+use Drupal\taxonomy\Entity\Term;
 
 /**
  * Implements hook_cron().
@@ -193,7 +194,42 @@ EOT;
 function fsa_gds_mp_count_by_alert_categories() {
   $category_counts = [];
 
+  // Get terms from the 'Alerts: Allergen' vocabulary.
+  $vocabulary = \Drupal::entityTypeManager()
+    ->getStorage('taxonomy_vocabulary')->load('alerts_allergen');
+  $allergy_terms = \Drupal::entityTypeManager()
+    ->getStorage('taxonomy_term')
+    ->loadTree($vocabulary->id());
+
+  foreach ($allergy_terms as $term) {
+    $term_entity = Term::load($term->tid);
+    $category_counts[$term_entity->field_alert_notation->value] = fsa_gds_mp_count_by_category($term->tid);
+  }
+
+
   return $category_counts;
+}
+
+/**
+ * Count query for users subscribed to a given allergy alert term id.
+ *
+ * @param int $term_id
+ *   Term ID of the allergy alert.
+ * @return int
+ *   The total number of matching users from the query.
+ */
+function fsa_gds_mp_count_by_category(int $term_id) {
+  if (empty($term_id)) {
+    return 0;
+  }
+
+  $user_count = \Drupal::entityQuery('user')
+    ->condition('field_subscribed_notifications', $term_id)
+    ->condition('status', 1)
+    ->count()
+    ->execute();
+
+  return (int) $user_count;
 }
 
 /**

--- a/drupal/web/modules/custom/fsa_gds_mp/fsa_gds_mp.module
+++ b/drupal/web/modules/custom/fsa_gds_mp/fsa_gds_mp.module
@@ -40,9 +40,160 @@ function fsa_gds_mp_cron() {
  */
 function fsa_gds_mp_gather_daily_metrics() {
   return [
-    'subscribe' => 12345,
-    'unsubscribe' => 100,
+    // Number of users subscribed in total.
+    'subscribed_users' => fsa_gds_mp_count_subscribed_users(),
+    // Amount of active subscriptions that receive message.
+    'active_subscribers' => fsa_gds_mp_count_active_subscribers(),
+    // Amount of active SMS subscriptions.
+    'active_sms_subscription' => fsa_gds_mp_count_active_sms_subscriptions(),
+    // Amount of active email subscriptions.
+    'active_email_subscription' => fsa_gds_mp_count_active_email_subscriptions(),
+    // Encoded JSON object containing subscriptions categories and how many subscribed per category.
+    'alert_categories' => fsa_gds_mp_count_by_alert_categories(),
   ];
+}
+
+/**
+ * Count the number of subscribed users, where subscribed means a user who has:
+ * 'Subscribed food alerts' checked
+ * - OR one selection in 'Subscribed news'
+ * - OR one selection in 'Subscribed consultations'
+ *
+ * @return int
+ *   The number of matching users.
+ */
+function fsa_gds_mp_count_subscribed_users() {
+  $connection = \Drupal::database();
+  $sql = <<<EOT
+    SELECT COUNT(DISTINCT u.uid)
+    FROM users u
+    LEFT JOIN user__field_subscribed_food_alerts fsfa ON fsfa.entity_id = u.uid
+    LEFT JOIN user__field_subscribed_news fsn ON fsn.entity_id = u.uid
+    LEFT JOIN user__field_subscribed_cons fsc ON fsc.entity_id = u.uid
+    WHERE 
+      fsfa.field_subscribed_food_alerts_value = 'all'
+    OR fsn.field_subscribed_news_target_id <> NULL 
+    OR fsc.field_subscribed_cons_target_id <> NULL; 
+EOT;
+
+  $query = $connection->query($sql);
+
+  return (int) $query->fetchAll();
+}
+
+/**
+ * Count the number of active subscriptions, meaning a user who has:
+ * - 'Subscribed food alerts' checked and at least one selection in
+ *   'Subscribed notifications' and either ('Email frequency' set to something
+ *   other than 'None and 'Food and allergy alert delivery method' with a
+ *   value including 'Email') or ('Food and allergy alert delivery method'
+ *   with a value including 'SMS' and 'Phone number' not empty)
+ * - OR one selection in 'Subscribed news' and
+ *   'News and consultations delivery method' selected.
+ * - OR one selection in 'Subscribed consultations' and and
+ *   'News and consultations delivery method' selected.
+ *
+ * @return int
+ *   The number of matching users.
+ */
+function fsa_gds_mp_count_active_subscribers() {
+  $connection = \Drupal::database();
+  $sql = <<<EOT
+    SELECT COUNT(DISTINCT u.uid)
+    FROM users u
+    INNER JOIN users_field_data ufd ON ufd.uid = u.uid
+    LEFT JOIN user__field_subscribed_food_alerts fsfa ON fsfa.entity_id = u.uid
+    LEFT JOIN user__field_subscribed_news fsn ON fsn.entity_id = u.uid
+    LEFT JOIN user__field_subscribed_cons fsc ON fsc.entity_id = u.uid
+    LEFT JOIN user__field_subscribed_notifications fsnot ON fsnot.entity_id = u.uid
+    LEFT JOIN user__field_delivery_method fdm ON fdm.entity_id = u.uid
+    LEFT JOIN user__field_delivery_method_news fdmnews ON fdmnews.entity_id = u.uid
+    LEFT JOIN user__field_email_frequency fef ON fef.entity_id = u.uid
+    LEFT JOIN user__field_notification_sms fns ON fns.entity_id = u.uid
+    WHERE
+        ufd.status = 1
+    AND (
+        (fsfa.field_subscribed_food_alerts_value = 'all' AND fsnot.field_subscribed_notifications_target_id IS NOT NULL)
+    )
+    AND (
+        (fdm.field_delivery_method_value LIKE '%email%' AND fef.field_email_frequency_value IS NOT NULL)
+        OR
+        (fdm.field_delivery_method_value LIKE '%sms%' AND fns.field_notification_sms_value IS NOT NULL)
+    )
+    OR (
+        fdmnews.field_delivery_method_news_value IS NOT NULL AND (
+            fsn.field_subscribed_news_target_id IS NOT NULL OR fsc.field_subscribed_cons_target_id IS NOT NULL
+        )
+    ); 
+EOT;
+
+  $query = $connection->query($sql);
+
+  return (int) $query->fetchAll();
+}
+
+/**
+ * Count all users who have an active SMS subscription, meaning:
+ * User has specified a delivery method value of 'sms' and has
+ * a phone number field value.
+ *
+ * @return int
+ *   The number of matching users.
+ */
+function fsa_gds_mp_count_active_sms_subscriptions() {
+  $connection = \Drupal::database();
+  $sql = <<<EOT
+    SELECT COUNT(DISTINCT u.uid)
+    FROM users u
+    INNER JOIN users_field_data ufd ON ufd.uid = u.uid
+    LEFT JOIN user__field_delivery_method fdm ON fdm.entity_id = u.uid
+    LEFT JOIN user__field_notification_sms fns ON fns.entity_id = u.uid
+    WHERE
+        ufd.status = 1
+    AND (fdm.field_delivery_method_value = 'sms' AND fns.field_notification_sms_value IS NOT NULL); 
+EOT;
+
+  $query = $connection->query($sql);
+
+  return (int) $query->fetchAll();
+}
+
+/**
+ * Count all users who have an active email subscription, meaning:
+ * User has specified a delivery method value of 'email' and has
+ * specified a delivery frequency value.
+ *
+ * @return int
+ *   The number of matching users.
+ */
+function fsa_gds_mp_count_active_email_subscriptions() {
+  $connection = \Drupal::database();
+  $sql = <<<EOT
+    SELECT COUNT(DISTINCT u.uid)
+    FROM users u
+    INNER JOIN users_field_data ufd ON ufd.uid = u.uid
+    LEFT JOIN user__field_delivery_method fdm ON fdm.entity_id = u.uid
+    LEFT JOIN user__field_email_frequency fef ON fef.entity_id = u.uid
+    WHERE
+        ufd.status = 1
+    AND (fdm.field_delivery_method_value = 'email' AND fef.field_email_frequency_value IS NOT NULL) 
+EOT;
+
+  $query = $connection->query($sql);
+
+  return (int) $query->fetchAll();
+}
+
+/**
+ * Count of subscribed users per alert category.
+ *
+ * @return array
+ *   [alert_machine_id, user_count]
+ */
+function fsa_gds_mp_count_by_alert_categories() {
+  $category_counts = [];
+
+  return $category_counts;
 }
 
 /**

--- a/drupal/web/modules/custom/fsa_gds_mp/fsa_gds_mp.module
+++ b/drupal/web/modules/custom/fsa_gds_mp/fsa_gds_mp.module
@@ -4,7 +4,6 @@
  * @file
  */
 
-use GuzzleHttp\Client as HttpClient;
 use Drupal\taxonomy\Entity\Term;
 
 /**
@@ -42,15 +41,15 @@ function fsa_gds_mp_cron() {
 function fsa_gds_mp_gather_daily_metrics() {
   return [
     // Number of users subscribed in total.
-    'subscribed_users' => fsa_gds_mp_count_subscribed_users(),
+    'Subscribed Users' => fsa_gds_mp_count_subscribed_users(),
     // Amount of active subscriptions that receive message.
-    'active_subscribers' => fsa_gds_mp_count_active_subscribers(),
+    'Active Users' => fsa_gds_mp_count_active_subscribers(),
     // Amount of active SMS subscriptions.
-    'active_sms_subscription' => fsa_gds_mp_count_active_sms_subscriptions(),
+    'Alert SMS' => fsa_gds_mp_count_active_sms_subscriptions(),
     // Amount of active email subscriptions.
-    'active_email_subscription' => fsa_gds_mp_count_active_email_subscriptions(),
+    'Alert Email' => fsa_gds_mp_count_active_email_subscriptions(),
     // Encoded JSON object containing subscriptions categories and how many subscribed per category.
-    'alert_categories' => fsa_gds_mp_count_by_alert_categories(),
+    'Alert Categories' => fsa_gds_mp_count_by_alert_categories(),
   ];
 }
 
@@ -251,13 +250,20 @@ function fsa_gsp_mp_send(array $payload) {
       'v' => 1,
       't' => 'event',
       'tid' => 'UA-54078849-3',
-      // 'cid' => '',.
       'ec' => 'Alerts%20Usage',
-      'ea' => 'Subscribed%20Users',
-      'ev' => 12345,
-    ]
+    ],
   ];
 
-  $client = new HttpClient();
-  $response = $client->request('POST', $uri, $options);
+  foreach ($payload as $event_id => $event_value) {
+    $event_id = urlencode($event_id);
+
+    if (is_array($event_value)) {
+      $event_value = json_encode($event_value);
+    }
+
+    $options['query']['ea'] = $event_id;
+    $options['query']['ev'] = $event_value;
+
+    \Drupal::httpClient()->post($uri, $options);
+  }
 }

--- a/drupal/web/modules/custom/fsa_gds_mp/fsa_gds_mp.module
+++ b/drupal/web/modules/custom/fsa_gds_mp/fsa_gds_mp.module
@@ -238,9 +238,7 @@ function fsa_gds_mp_count_by_category(int $term_id) {
  * @throws \GuzzleHttp\Exception\GuzzleException
  */
 function fsa_gsp_mp_send(array $payload) {
-  // Debugging with netcat.
-  $uri = 'http://localhost:6666';
-  // $uri = 'https://www.google-analytics.com/collect';
+  $uri = 'https://www.google-analytics.com/collect';
   // Measurement protocol API docs here: https://developers.google.com/analytics/devguides/collection/protocol/v1/devguide#event.
   $options = [
     'headers' => [
@@ -249,8 +247,13 @@ function fsa_gsp_mp_send(array $payload) {
     'query' => [
       'v' => 1,
       't' => 'event',
-      'tid' => 'UA-54078849-3',
+      'tid' => \Drupal::config('fsa_gds_mp')->get('ga_tracking_id'),
+      'cid' => \Drupal::service('uuid')->generate(),
+      'ds' => 'drupal',
+      'dh' => \Drupal::request()->getHost(),
+      'dt' => urlencode('Statistics reporting'),
       'ec' => 'Alerts%20Usage',
+      'ev' => 0,
     ],
   ];
 
@@ -262,7 +265,7 @@ function fsa_gsp_mp_send(array $payload) {
     }
 
     $options['query']['ea'] = $event_id;
-    $options['query']['ev'] = $event_value;
+    $options['query']['el'] = $event_value;
 
     \Drupal::httpClient()->post($uri, $options);
   }

--- a/drupal/web/sites/default/settings.php
+++ b/drupal/web/sites/default/settings.php
@@ -116,6 +116,9 @@ switch ($env) {
     $config['warden.settings']['warden_preg_match_custom'] = '{^modules\/custom\/*}';
     $config['warden.settings']['warden_preg_match_contrib'] = '{^modules\/contrib\/*}';
 
+    // FSA Data Studio Measurement Protocol: switch UA- code to correct ID.
+    $config['fsa_gds_mp']['ga_tracking_id'] = 'UA-54078849-1';
+
     break;
 
   case 'develop':
@@ -125,6 +128,8 @@ switch ($env) {
     $config['google_tag.settings']['environment_id'] = 'env-6';
     $config['google_tag.settings']['environment_token'] = '4d3H88TmNOCwXVDx0PK8bg';
 
+    $config['fsa_gds_mp']['ga_tracking_id'] = 'UA-54078849-3';
+
     break;
 
   case 'stage':
@@ -133,6 +138,8 @@ switch ($env) {
     // GTM Environment overrides.
     $config['google_tag.settings']['environment_id'] = 'env-5';
     $config['google_tag.settings']['environment_token'] = 'nNEwJ_lItnO48_pabdUErg';
+
+    $config['fsa_gds_mp']['ga_tracking_id'] = 'UA-54078849-3';
 
     break;
 
@@ -145,6 +152,8 @@ switch ($env) {
     // GTM Environment (below values should be as default configurations).
     $config['google_tag.settings']['environment_id'] = 'env-7';
     $config['google_tag.settings']['environment_token'] = 'a4fGxt3oZ4lNeD1SjVDqdA';
+
+    $config['fsa_gds_mp']['ga_tracking_id'] = 'UA-54078849-3';
 
     break;
 }


### PR DESCRIPTION
This PR aims to:

- Provide a daily task to gather subscription/alerts related data and make them available in Google Data Studio by sending HTTP requests to the Measurement Protocol endpoint. This allows arbitrary events or page impressions to be registered in Google Analytics, which in turn can be interrogated from Data Studio.

Marked as WIP at the moment as waiting for confirmation from FSA about what, precisely, a subscribed vs active subscribed user means in terms of notification/delivery method field values combinations. At the time of writing this contains my own 'best guess' at what this would equate to.

NB: implementation for this is kept intentionally as simple as possible for a quick turnaround (this isn't billable). Could later be abstracted or plugged into DI container for any tests.