### PR TITLE
FSA-1165: enable site verification metatag module and add FSA Google code to front page

### DIFF
--- a/drupal/sync/core.extension.yml
+++ b/drupal/sync/core.extension.yml
@@ -111,6 +111,7 @@ module:
   metatag_google_plus: 0
   metatag_open_graph: 0
   metatag_twitter_cards: 0
+  metatag_verification: 0
   migrate: 0
   migrate_plus: 0
   migrate_tools: 0

--- a/drupal/sync/metatag.metatag_defaults.front.yml
+++ b/drupal/sync/metatag.metatag_defaults.front.yml
@@ -7,8 +7,9 @@ _core:
 id: front
 label: 'Front page'
 tags:
-  canonical_url: '[site:url]'
   shortlink: '[site:url]'
+  canonical_url: '[site:url]'
   og_image: '[site:url]/themes/custom/fsa/share-default.png'
   og_url: '[site:url]'
   twitter_cards_image: '[site:url]/themes/custom/fsa/share-default.png'
+  google: QKdwbKx5K9wx94C9VRt1d5n4EH22aI7MVGUfA1w8raE


### PR DESCRIPTION
Requested by Sally, requires a small amount of configuration to show a meta tag on the front page for the site to validate in Google Webmaster Tools.